### PR TITLE
feat: remove pnpm from the scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 **/pnpm-lock.yaml
 **/package-lock.json
 
-db-mysql/*
+db-mysql/dev/
+db-mysql/prod/
 !db/dev/.gitkeep
 !db/prod/.gitkeep
 

--- a/Dockerfile.back
+++ b/Dockerfile.back
@@ -1,15 +1,13 @@
 FROM node:20-slim AS base
 WORKDIR /usr/src/app
-# RUN npm i -g pnpm
 
 FROM base AS dependencies
-COPY ./back-express/package.json ./
-COPY ./back-express/*-lock.json ./
+COPY ./back-express/package*.json ./
 RUN npm i --prod=false
 
 FROM dependencies AS development
 CMD [ "npm", "run", "start" ]
-EXPOSE 3005
+EXPOSE $BACK_PORT
 
 FROM dependencies AS build
 COPY ./back-express .
@@ -21,4 +19,4 @@ COPY --from=dependencies /usr/src/app/node_modules ./node_modules
 ENV NODE_ENV=production
 COPY --from=build /usr/src/app/dist ./dist
 RUN npm prune --prod
-CMD [ "node", "dist/index.js" ]
+CMD [ "node", "dist/app.js" ]

--- a/Dockerfile.front
+++ b/Dockerfile.front
@@ -1,12 +1,8 @@
 FROM node:20-slim AS base
 WORKDIR /usr/src/app
-# RUN npm i -g pnpm
 
 FROM base AS dependencies
-COPY ./front-nuxt/package.json ./
-COPY ./front-nuxt/*-lock.json ./
-# RUN mkdir -p /.pnpm-store && \
-#     pnpm config set store-dir /.pnpm-store
+COPY ./front-nuxt/package*.json ./
 RUN npm i --prod=false
 
 FROM dependencies AS development

--- a/back-express/nodemon.json
+++ b/back-express/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "exec": "ts-node ./src/app.ts"
+}

--- a/db-mysql/scripts/init_tables.sql
+++ b/db-mysql/scripts/init_tables.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `match`.account (
+    account_id INTEGER UNSIGNED auto_increment NOT NULL,
+    email varchar(100) NOT NULL,
+    password varchar(100) NOT NULL,
+    google_username varchar(100) NULL,
+    `42intra_username` varchar(100) NULL,
+    status ENUM('active', 'inactive', 'pending') NOT NULL DEFAULT 'inactive', -- Default value set to 'inactive'
+    CONSTRAINT account_id PRIMARY KEY (account_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   front:
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   server:
     container_name: "server-nginx"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       - "${DB_PORT}:3306" # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
     container_name: "db-mysql"
     image: mysql:latest
+    volumes:
+      - ./db-mysql/scripts:/docker-entrypoint-initdb.d
     environment:
       - TZ=Europe/Paris
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,13 +33,13 @@ services:
       dockerfile: Dockerfile.back
     env_file:
       - ./.env
-    # depends_on:
-    #   db:
-    #     condition: service_healthy
+    depends_on:
+      db:
+        condition: service_healthy
     networks:
       - server_network
       - data_network
-    # restart: unless-stopped
+    restart: unless-stopped
 
   db:
     ports:


### PR DESCRIPTION
pnpm 관련 내용들을 제거 하였습니다

+ 추가로 db-mysql 폴더에 'scripts' 라는 폴더를 만들었습니다. orm 기능은 따로 구현 해야겠지만


볼륨마운트 해놓은 디렉토리 `docker-entrypoint-initdb.d` 에 있는 스크립트들을 알파벳 순서로 생성합니다 (https://hub.docker.com/_/mysql 에서 'Initializing a fresh instance' 검색해서 보세요)

테이블 생성 용도로 sql 쿼리 스크립트들을 'scripts' 폴더에 저장하고 관리 하려고 합니다
