### PR TITLE
fastapi - verify email

### DIFF
--- a/back-fastapi/constants.py
+++ b/back-fastapi/constants.py
@@ -2,8 +2,8 @@ from enum import Enum
 import os
 
 class AccountStatus(Enum):
-    INCOMPLETE_PROFILE = "incomplete_profile"
     PENDING_VERIFICATION = "pending_verification"
+    INCOMPLETE_PROFILE = "incomplete_profile"
     LOGIN = "login"
     LOGOUT = "logout"
 

--- a/back-fastapi/constants.py
+++ b/back-fastapi/constants.py
@@ -1,0 +1,30 @@
+from enum import Enum
+import os
+
+class AccountStatus(Enum):
+    INCOMPLETE_PROFILE = "incomplete_profile"
+    PENDING_VERIFICATION = "pending_verification"
+    LOGIN = "login"
+    LOGOUT = "logout"
+
+NGINX_HOST = os.getenv("NGINX_HOST")
+FASTAPI_HOST = os.getenv("FASTAPI_HOST")
+DOMAIN = os.getenv("DOMAIN")
+ENV = "development" # "production"
+
+# Get database info from .env
+DB_PORT = int(os.getenv("DB_PORT"))
+DB_HOST = os.getenv("MYSQL_HOST")
+DB_USER = os.getenv("MYSQL_USER")
+DB_PASSWORD = os.getenv("MYSQL_PASSWORD")
+DB_DATABASE = os.getenv("MYSQL_DATABASE")
+
+# Secret key for encoding and decoding JWT
+JWT_SECRET = os.getenv("JWT_SECRET", "i_do_not_care_anymore")
+JWT_ACCESS_DURATION = int(os.getenv("JWT_ACCESS_DURATION"))
+JWT_REFRESH_DURATION = int(os.getenv("JWT_REFRESH_DURATION"))
+
+# google email
+GMAIL_ID = os.getenv("GMAIL_ID")
+GMAIL_PASSWORD = os.getenv("GMAIL_PASSWORD")
+

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -1,7 +1,12 @@
+from typing import Dict, Any
 from fastapi import Response
 from fastapi import status
 from fastapi import APIRouter
 from fastapi import HTTPException, Query
+from src.models import dto
+
+import src.services.auth_service as auth_service
+import src.services.email_service as email_service
 import src.services.account_service as account_service
 
 
@@ -14,24 +19,65 @@ router = APIRouter(
 # pydantic validator 안 쓸시 response_model=None 지정 필수
 # TODO: data validation
 @router.post("/register", status_code=status.HTTP_201_CREATED, response_model=None)
-async def register(data: dict, lang: str = Query("en")):
+async def register(data: Dict[str, Any], lang: str = Query("en")):
     """
     Register a new user account.
 
     Args:
-        user (dict): The user data(username, email, password)
+        data (dict): The user data(username, email, password)
         lang (str) : Specific language selector
 
     Raises:
         HTTPException: If the account already exists or if there are issues during registration.
     """
     username, email, password = data.values()
-    print("register", username, email, password, lang)
+    print("register", data, lang)
     # TODO: i18n error messages in en and fr
     if lang not in ["en", "fr"]:
         lang = "en"
 
     await account_service.check_account(username, email)
 
-    account_id = await account_service.create_account(username, email, password, user_status="pending_verification")
-    print("id:", account_id)
+    account_id = await account_service.create_account(username, email, password)
+    print("account id:", account_id)
+
+    return {
+        "accountId": account_id,
+        "username": username,
+        "email": email,
+    }
+
+@router.post("/request-email", status_code=status.HTTP_200_OK, response_model=None)
+async def request_email(data: Dict[str, Any], res: Response, lang: str = Query("en")):
+    print(data)
+    account_id, username, email = data.values()
+    access_token = auth_service.set_token_cookies(res, account_id)
+    print("access token:", access_token)
+
+    await email_service.send_verification_email(
+        {
+            "account_id": account_id,
+            "username": username, 
+            "email": email
+        }, 
+        lang,
+        access_token
+    )
+
+    return {
+        "accountId": account_id,
+        "username": username, 
+        "email": email,
+        "accessToken": access_token
+    }
+
+
+@router.get("/verify-email", status_code=status.HTTP_200_OK, response_model=None)
+async def verify_email(res: Response, token: str, lang: str = Query("en")):
+    print(token, lang)
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token is required",
+        )
+    return await email_service.verify_email(res, token, lang)

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -36,8 +36,6 @@ async def register(data: Dict[str, Any], lang: str = Query("en")):
     if lang not in ["en", "fr"]:
         lang = "en"
 
-    await account_service.check_account(username, email)
-
     account_id = await account_service.create_account(username, email, password)
     print("account id:", account_id)
 
@@ -47,8 +45,9 @@ async def register(data: Dict[str, Any], lang: str = Query("en")):
         "email": email,
     }
 
+# TODO: data validation
 @router.post("/request-email", status_code=status.HTTP_200_OK, response_model=None)
-async def request_email(data: Dict[str, Any], res: Response, lang: str = Query("en")):
+async def request_email(res: Response, data: Dict[str, Any], lang: str = Query("en")):
     print(data)
     account_id, username, email = data.values()
     access_token = await auth_service.set_token_cookies(res, account_id)

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -13,7 +13,7 @@ import src.services.account_service as account_service
 # fastapi dev랑 run(prod)으로 실행시 각가 다르게 동작
 router = APIRouter(
     # prefix="/auth", 
-    # tags=["Auth"]
+    tags=["Auth"]
 )
 
 # pydantic validator 안 쓸시 response_model=None 지정 필수
@@ -51,7 +51,7 @@ async def register(data: Dict[str, Any], lang: str = Query("en")):
 async def request_email(data: Dict[str, Any], res: Response, lang: str = Query("en")):
     print(data)
     account_id, username, email = data.values()
-    access_token = auth_service.set_token_cookies(res, account_id)
+    access_token = await auth_service.set_token_cookies(res, account_id)
     print("access token:", access_token)
 
     await email_service.send_verification_email(

--- a/back-fastapi/src/models/db.py
+++ b/back-fastapi/src/models/db.py
@@ -3,15 +3,7 @@ from mysql.connector import Error
 from fastapi import HTTPException
 from fastapi import Depends
 import aiomysql
-import os
-
-# Get database info from .env
-DB_PORT = int(os.getenv("DB_PORT"))
-# DB_HOST = os.getenv("MYSQL_HOST")
-DB_USER = os.getenv("MYSQL_USER")
-DB_PASSWORD = os.getenv("MYSQL_PASSWORD")
-DB_DATABASE = os.getenv("MYSQL_DATABASE")
-
+from constants import DB_PORT, DB_USER, DB_PASSWORD, DB_DATABASE
 
 class Database:
     def __init__(self, db_info):

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -63,6 +63,23 @@ async def update_status(account_id: int, account_status: str) -> None:
                 status_code=status.HTTP_400_BAD_REQUEST
             )
 
+async def update_refresh_token(account_id: int, token: str) -> None:
+    connection = await get_db_connection()
+    async with connection.cursor(DictCursor) as cursor:
+        try:
+            await cursor.execute(
+                'UPDATE account SET refresh_token = %s WHERE account_id = %s',
+                (token, account_id)
+            )
+            await connection.commit()
+            print("account refresh token updated: ", token, account_id)
+        except Exception as e:
+            print(e)
+            raise HTTPException(
+                detail=str(e),
+                status_code=status.HTTP_400_BAD_REQUEST
+            )
+
 async def get_by_id(account_id: int) -> Dict[str, Any]:
     connection = await get_db_connection()
     async with connection.cursor(DictCursor) as cursor:

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -1,10 +1,11 @@
+from typing import Dict, Any
 from fastapi import HTTPException
 from fastapi import status
 from aiomysql import DictCursor
 
 from src.models.db import get_db_connection
 
-async def check_account(username: str, email: str) -> None: 
+async def check(username: str, email: str) -> None: 
     connection = await get_db_connection()
     async with connection.cursor(DictCursor) as cursor:
         # check by username
@@ -26,17 +27,17 @@ async def check_account(username: str, email: str) -> None:
                 status_code=status.HTTP_409_CONFLICT
             )
 
-async def create_account(username: str, email: str, password:str, user_status:str) -> int:
+async def create(username: str, email: str, password:str, account_status:str) -> int:
     connection = await get_db_connection()
     async with connection.cursor(DictCursor) as cursor:
         try:
-            print("creating account...")
+            print("creating account...", account_status)
             await cursor.execute(
                 'INSERT INTO account (username, email, password, status) VALUES (%s, %s, %s, %s)',
-                (username, email, password, user_status)
+                (username, email, password, account_status)
             )
             await connection.commit()
-            print("user created: ", username)
+            print("account created: ", username)
             return cursor.lastrowid
         except Exception as e:
             print(e)
@@ -44,5 +45,37 @@ async def create_account(username: str, email: str, password:str, user_status:st
                 detail=str(e),
                 status_code=status.HTTP_400_BAD_REQUEST
             )
-        # finally:
-        #     await connection.close()
+
+async def update_status(account_id: int, account_status: str) -> None:
+    connection = await get_db_connection()
+    async with connection.cursor(DictCursor) as cursor:
+        try:
+            await cursor.execute(
+                'UPDATE account SET status = %s WHERE account_id = %s',
+                (account_status, account_id)
+            )
+            await connection.commit()
+            print("account status updated: ", account_status, account_id)
+        except Exception as e:
+            print(e)
+            raise HTTPException(
+                detail=str(e),
+                status_code=status.HTTP_400_BAD_REQUEST
+            )
+
+async def get_by_id(account_id: int) -> Dict[str, Any]:
+    connection = await get_db_connection()
+    async with connection.cursor(DictCursor) as cursor:
+        try:
+            await cursor.execute(
+                'SELECT * FROM account WHERE account_id = %s', (account_id, )
+            )
+            account = await cursor.fetchone()
+            # print("account: ", account)
+            return account
+        except Exception as e:
+            print(e)
+            raise HTTPException(
+                detail=str(e),
+                status_code=status.HTTP_400_BAD_REQUEST
+            )

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -78,6 +78,25 @@ async def update_account_status(account_id: int, account_status: str) -> None:
     
     await account_repository.update_status(account_id, account_status)
 
+async def update_account_refresh_token(account_id: int, token: str) -> None:
+    """
+    Update the refresh token of an account.
+
+    Args:
+        account_id (int): The ID of the account to update.
+        token (str): The new refresh token to set for the account.
+
+    Raises:
+        HTTPException: If the account refresh token is invalid.
+    """
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid token"
+        )
+    
+    await account_repository.update_refresh_token(account_id, token)
+
 async def get_account_by_id(account_id: int) -> Dict[str, Any]:
     """
     Retrieve an account by its ID.

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -41,6 +41,8 @@ async def create_account(username: str, email: str, password:str) -> int:
         account_id (int): Created account id
     """
     print("create_account(): ", username, email, password)
+    await check_account(username, email)
+
 
     if not password:
         raise HTTPException(
@@ -75,7 +77,7 @@ async def update_account_status(account_id: int, account_status: str) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid account status: {account_status}. Must be one of {[status.value for status in AccountStatus]}",
         )
-    
+    await get_account_by_id(account_id)
     await account_repository.update_status(account_id, account_status)
 
 async def update_account_refresh_token(account_id: int, token: str) -> None:
@@ -94,7 +96,7 @@ async def update_account_refresh_token(account_id: int, token: str) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid token"
         )
-    
+    await get_account_by_id(account_id)
     await account_repository.update_refresh_token(account_id, token)
 
 async def get_account_by_id(account_id: int) -> Dict[str, Any]:

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -1,12 +1,10 @@
+from typing import Dict, Any
 from jose import JWTError, jwt
+from fastapi import Response, HTTPException, status
 from passlib.context import CryptContext
-from datetime import datetime, timedelta
-import os
+from datetime import datetime, timedelta, timezone
 
-# Secret key for encoding and decoding JWT
-JWT_SECRET = os.getenv("JWT_SECRET", "i_do_not_care_anymore")
-JWT_ACCESS_DURATION = os.getenv("JWT_ACCESS_DURATION")
-JWT_REFRESH_DURATION = os.getenv("JWT_REFRESH_DURATION")
+from constants import JWT_SECRET, JWT_ACCESS_DURATION, JWT_REFRESH_DURATION, DOMAIN, ENV
 
 # Password hasing context
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -16,3 +14,81 @@ def hash_password(password: str) -> str:
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
+
+def create_access_token(account_id: int, expire_delta: timedelta=None) -> str:
+    payload = {"accountId": account_id}
+    if expire_delta:
+        expire = datetime.now(timezone.utc) + expire_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=JWT_ACCESS_DURATION)
+    payload.update({"exp": expire})
+    token = jwt.encode(payload, JWT_SECRET)
+
+    cookie_options = {
+        "domain": DOMAIN,
+        "path": "/",
+        "httponly": True,
+        "secure": ENV == "production",
+        "expires": expire
+    }
+    
+    return {
+        "accessToken": token,
+        "options": cookie_options
+    }
+
+def create_refresh_token(account_id: int, expire_delta: timedelta=None) -> str:
+    payload = {"accountId": account_id}
+    if expire_delta:
+        expire = datetime.now(timezone.utc) + expire_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=JWT_REFRESH_DURATION)
+    payload.update({"exp": expire})
+    token = jwt.encode(payload, JWT_SECRET)
+    
+    cookie_options = {
+        "domain": DOMAIN,
+        "path": "/",
+        "httponly": True,
+        "secure": ENV == "production",
+        "expires": expire
+    }
+    
+    return {
+        "refreshToken": token,
+        "options": cookie_options
+    }
+
+def set_token_cookies(res: Response, account_id: int) -> str:
+    try:
+        access_token_info = create_access_token(account_id)
+        refresh_token_info = create_refresh_token(account_id)
+
+        res.set_cookie(key="accessToken", value=access_token_info["accessToken"],
+                        httponly=access_token_info["options"]["httponly"], 
+                        secure=access_token_info["options"]["secure"],
+                        expires=access_token_info["options"]["expires"])
+        res.set_cookie(key="refreshToken", value=refresh_token_info["refreshToken"],
+                        httponly=refresh_token_info["options"]["httponly"], 
+                        secure=refresh_token_info["options"]["secure"],
+                        expires=refresh_token_info["options"]["expires"])
+
+        # await save_refresh_token(account_id, refresh_token_info["refreshToken"])
+    except Exception as e:
+        raise HTTPException(
+            detail="Error generating tokens",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+    return access_token_info["accessToken"]
+
+def decode_token(token: str):
+    try:
+        payload = jwt.decode(token, JWT_SECRET)
+        return payload
+    except JWTError as e:
+        print("JWTError:", e)
+        return None
+    
+
+def save_refresh_token(account_id: int, refresh_token: str):
+    pass

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -66,6 +66,9 @@ async def save_refresh_token(account_id: int, refresh_token: str) -> None:
 
 async def set_token_cookies(res: Response, account_id: int) -> str:
     try:
+        # account check
+        await account_service.get_account_by_id(account_id)
+
         access_token_info = create_access_token(account_id)
         refresh_token_info = create_refresh_token(account_id)
 

--- a/back-fastapi/src/services/email_service.py
+++ b/back-fastapi/src/services/email_service.py
@@ -1,0 +1,65 @@
+from typing import Dict, Any
+from aiosmtplib import SMTP
+from fastapi import Response, HTTPException, status
+from fastapi.responses import RedirectResponse
+from email.message import EmailMessage
+from constants import FASTAPI_HOST, GMAIL_ID, GMAIL_PASSWORD, NGINX_HOST, AccountStatus
+
+import src.services.auth_service as auth_service
+import src.services.account_service as account_service
+
+
+# TODO: data validation
+async def send_verification_email(data: Dict[str, Any], lang: str, token: str) -> None:
+    account_id, username, email = data.values()
+    print("send_verification_email():", lang, account_id, username, email)
+
+    subject_template = {
+        'en': '[Matcha-reloaded] Verify your email',
+        'fr': '[Matcha-reloaded] Verifier votre email'
+    }
+
+    html_template = {
+        'en': f'<a href="{FASTAPI_HOST}/verify-email?token={token}&lang=en">Verify your email for username: {username}</a>',
+        'fr': f'<a href="{FASTAPI_HOST}/verify-email?token={token}&lang=fr">Vérifiez votre email pour votre username: {username}</a>',
+    }
+
+
+
+    subject = subject_template.get(lang, subject_template['en'])
+    html = html_template.get(lang, html_template['en'])
+
+    message = EmailMessage()
+    message['From'] = GMAIL_ID
+    message['To'] = email
+    message['Subject'] = subject
+    message.set_content(html, subtype='html')
+
+    async with SMTP(hostname='smtp.gmail.com', port=587, start_tls=True) as smtp:
+        await smtp.login(GMAIL_ID, GMAIL_PASSWORD)
+        await smtp.send_message(message)
+
+async def verify_email(res: Response, token: str, lang: str):
+    # TODO: access token 만료시 에러처리
+    payload = auth_service.decode_token(token)
+    print("service verify_email() payload:", payload)
+    # access token 만료시
+    if payload is None:
+        # temp exception
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired"
+        )
+        # example
+        redirect_url = f'{NGINX_HOST}/{lang}/auth/request-email'
+        return RedirectResponse(url=redirect_url)
+    account_id = payload["accountId"]
+
+    account = await account_service.get_account_by_id(account_id)
+    # print("service verify_email() account:", account)
+
+    await account_service.update_account_status(account_id, AccountStatus.INCOMPLETE_PROFILE.value)
+    auth_service.set_token_cookies(res, account_id)
+
+    redirect_url = f'{NGINX_HOST}/{lang}/auth/generate-profile'
+    return RedirectResponse(url=redirect_url)

--- a/back-fastapi/src/services/email_service.py
+++ b/back-fastapi/src/services/email_service.py
@@ -59,7 +59,7 @@ async def verify_email(res: Response, token: str, lang: str):
     # print("service verify_email() account:", account)
 
     await account_service.update_account_status(account_id, AccountStatus.INCOMPLETE_PROFILE.value)
-    auth_service.set_token_cookies(res, account_id)
+    await auth_service.set_token_cookies(res, account_id)
 
     redirect_url = f'{NGINX_HOST}/{lang}/auth/generate-profile'
     return RedirectResponse(url=redirect_url)

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -3,12 +3,56 @@ import type { AxiosInstance } from 'axios';
 import type { AccountData, ProfileData } from '~/types';
 
 export const useAuth = () => {
+  const axios = useAxios();
   const BACK_HOST = useRuntimeConfig().public.BACK_HOST;
   const { accountData, profileData } = storeToRefs(useUserStore());
   const refreshTokenIntervalId = ref();
   const tokenDurationMins = Number(
     useRuntimeConfig().public.JWT_ACCESS_DURATION,
   );
+
+  const doRegister = async (
+    info: AccountData,
+    lang: string,
+    socialLogin: Record<string, any> = {},
+  ) => {
+    try {
+      let endpoint = '/register'; // Default to plain register
+
+      const payload = { ...info } as Record<string, any>;
+      // If it's a social login, use the social registration endpoint
+      if (Object.keys(socialLogin).length > 0) {
+        endpoint = '/social-register';
+        payload.socialInfo = socialLogin; // Dynamically add socialInfo field
+      }
+
+      const { data } = await axios.post(`${endpoint}?lang=${lang}`, payload);
+      // Set user data and trigger the refresh auth process
+      accountData.value = data;
+      console.log('doRegister acconutData:', accountData.value);
+      startRefreshAuth();
+
+      return data; // Return data if needed for further handling
+    } catch (error) {
+      console.error('Error during registration:', error);
+      throw error; // Rethrow error for caller to handle
+    }
+  };
+
+  const doRequestEmail = async (lang: string) => {
+    try {
+      const { data } = await axios.post(
+        `/request-email?lang=${lang}`,
+        accountData.value,
+      );
+      accountData.value = data;
+      console.log('doRequestEmail acconutData:', accountData.value);
+      startRefreshAuth();
+    } catch (error) {
+      console.error('Error during request email:', error);
+      throw error;
+    }
+  };
 
   const doRefreshTokenServer = async () => {
     if (accountData.value.accountId) return;
@@ -29,7 +73,6 @@ export const useAuth = () => {
   };
 
   const doRefreshTokenClient = async () => {
-    const axios = useAxios();
     try {
       const { data } = await axios.post(`/refresh`);
       accountData.value = data || {};
@@ -95,39 +138,6 @@ export const useAuth = () => {
     await api.post(`/forgot-password?lang=${lang}`, info);
   };
 
-  const doRegister = async (
-    api: AxiosInstance,
-    info: AccountData,
-    lang: string,
-    socialLogin: Record<string, any> = {},
-  ) => {
-    try {
-      let endpoint = '/register'; // Default to plain register
-
-      const payload = { ...info } as Record<string, any>;
-      // If it's a social login, use the social registration endpoint
-      if (Object.keys(socialLogin).length > 0) {
-        endpoint = '/social-register';
-        payload.socialInfo = socialLogin; // Dynamically add socialInfo field
-      }
-
-      // Make API request to the appropriate endpoint
-      const { data } = await api.post(
-        `${BACK_HOST}${endpoint}?lang=${lang}`,
-        payload,
-      );
-      // Set user data and trigger the refresh auth process
-      accountData.value = data;
-      console.log('acconutData check', accountData.value);
-      startRefreshAuth();
-
-      return data; // Return data if needed for further handling
-    } catch (error) {
-      console.error('Error during registration:', error);
-      throw error; // Rethrow error for caller to handle
-    }
-  };
-
   const onGoogleLogin = () => (window.location.href = `${BACK_HOST}/google`);
 
   const onFtLogin = () => (window.location.href = `${BACK_HOST}/ft`);
@@ -143,6 +153,7 @@ export const useAuth = () => {
     doLogin,
     doLogout,
     doRegister,
+    doRequestEmail,
     doCheckUserCredentials,
     onGoogleLogin,
     onFtLogin,

--- a/front-nuxt/pages/auth/register.vue
+++ b/front-nuxt/pages/auth/register.vue
@@ -101,7 +101,6 @@
   import { useRoute } from 'vue-router';
   import { jwtDecode } from 'jwt-decode';
 
-  const axios = useAxios();
   const username = ref('');
   const email = ref('');
   const password = ref('');
@@ -126,7 +125,7 @@
     t,
   );
 
-  const { doRegister } = useAuth();
+  const { doRegister, doRequestEmail } = useAuth();
   const { locale } = useI18n();
   const route = useRoute();
 
@@ -179,7 +178,8 @@
       // if (token.value) {
       //   console.log('token check', token.value);
       // }
-      await doRegister(axios, userInfo, locale.value, socialInfo);
+      await doRegister(userInfo, locale.value, socialInfo);
+      await doRequestEmail(locale.value);
       await navigateTo({ path: localePath('auth-verify-email') });
     } catch (e) {
       if (e.response && e.response.data.code) {


### PR DESCRIPTION
# fastapi verify email 구현하기

## token
- [x] create access, refresh tokens
- [x] set cookies for tokens
- [x] save refresh token to db

## verify email
- [x] request-email api: resgister에서 분리
- [x] send verification email
- [x] 이메일 확인 후 verify-email redirection


verify email logic구현입니다. 이메일 보내는 로직을 register에서 분리해서 따로 request-email api만들었습니다.
- 추후에 access token이 만료되었을 시 이메일 재요청 페이지 리다이렉션필요합니다. (프론트 페이지 및 api 필요)