### PR TITLE
refactort: validator and dto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# miniconda setup script
+Miniconda3-latest-Linux-x86_64.sh

--- a/alias.sh
+++ b/alias.sh
@@ -29,6 +29,7 @@ alias back-dev-seed-run='docker compose -f docker-compose.yml -f docker-compose.
 
 
 ## docker related commands
+alias docker-rm-db-goinfre="docker run --rm -v ./db-mysql/dev:/mnt -u 0 alpine sh -c \"rm -rf /mnt/*\""
 alias docker-rm-all-images='docker rmi $(docker images -a -q)'
 alias docker-rm-all-containers='docker rm $(docker ps -a -q)'
 alias docker-rm-all-volumes='docker volume rm $(docker volume ls -q --filter dangling=true)'

--- a/back-express/src/models/account.model.ts
+++ b/back-express/src/models/account.model.ts
@@ -148,17 +148,17 @@ export async function updateAccountPasswordAndStatus(
   );
 }
 
-export const updateAccountStatus = async (accountId: number, status: string): Promise<void> => {
+export const updateAccountStatus = async (account_id: number, status: string): Promise<void> => {
   const connection = await pool.getConnection();
   try {
     const query = 'UPDATE account SET status = ? WHERE account_id = ?';
-    const [result]: any = await connection.query(query, [status, accountId]);
+    const [result]: any = await connection.query(query, [status, account_id]);
 
     if (result.affectedRows === 0) {
-      throw new Error(`Account with ID ${accountId} not found`);
+      throw new Error(`Account with ID ${account_id} not found`);
     }
 
-    console.log(`Account ${accountId} updated successfully to status ${status}`);
+    console.log(`Account ${account_id} updated successfully to status ${status}`);
   } finally {
     connection.release();
   }

--- a/back-fastapi/constants.py
+++ b/back-fastapi/constants.py
@@ -10,6 +10,9 @@ class AccountStatus(Enum):
     OFFLINE = "offline"
 
 
+DEFAULT_MAX = 20
+DEFAULT_MIN = 2
+
 NGINX_HOST = os.getenv("NGINX_HOST")
 BACK_HOST = os.getenv("BACK_HOST")
 FRONT_HOST = os.getenv("FRONT_HOST")

--- a/back-fastapi/constants.py
+++ b/back-fastapi/constants.py
@@ -3,10 +3,11 @@ from enum import Enum
 
 
 class AccountStatus(Enum):
-    PENDING_VERIFICATION = "pending_verification"
+    INCOMPLETE_SOCIAL = "incomplete_social"
     INCOMPLETE_PROFILE = "incomplete_profile"
-    LOGIN = "login"
-    LOGOUT = "logout"
+    PENDING_VERIFICATION = "pending_verification"
+    ONLINE = "online"
+    OFFLINE = "offline"
 
 
 NGINX_HOST = os.getenv("NGINX_HOST")

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -17,7 +17,6 @@ router = APIRouter(
 
 
 # pydantic validator 안 쓸시 response_model=None 지정 필수
-# TODO: data validation: username, email, password
 @router.post("/register", status_code=status.HTTP_201_CREATED, response_model=None)
 async def register(
     res: Response,
@@ -41,9 +40,7 @@ async def register(
         created_account.accessToken = access_token
         return created_account
     except HTTPException as e:
-        if e.status_code == status.HTTP_409_CONFLICT:
-            return JSONResponse(status_code=e.status_code, content=e.detail)
-        return JSONResponse(status_code=e.status_code, content={"code": "INVALID_LOGIN"})
+        return JSONResponse(status_code=e.status_code, content=e.detail)
     except Exception:
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"code": "GENERAL_ERROR"}

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -94,9 +94,9 @@ async def logout(res: Response, access_token: str = Cookie(None)):
 
 
 @router.post("/refresh", status_code=status.HTTP_200_OK, response_model=None)
-async def refresh(res: Response, refreshToken: str = Cookie(None)):
-    print("refresh():", refreshToken)
-    return await auth_service.refresh(res, refreshToken)
+async def refresh(res: Response, refresh_token: str = Cookie(None)):
+    print("refresh():", refresh_token)
+    return await auth_service.refresh(res, refresh_token)
 
 
 # TODO: data validation: email

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -79,7 +79,7 @@ async def login(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     try:
         return await auth_service.authenticate(res, data)
     except HTTPException as e:
-        return JSONResponse(status_code=e.status_code, content=e.detail)
+        return JSONResponse(status_code=e.status_code, content={"code":e.detail})
     except Exception as e:
         print("e2", e)
         return JSONResponse(

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -34,7 +34,7 @@ router = APIRouter(
 # pydantic validator 안 쓸시 response_model=None 지정 필수
 # TODO: data validation: username, email, password
 @router.post("/register", status_code=status.HTTP_201_CREATED, response_model=None)
-async def register(res: Response, data: RegisterAccountDTO):
+async def register(res: Response, data: RegisterAccountDTO, lang: str = Query("en")):
     """
     Register a new user account.
 
@@ -48,6 +48,7 @@ async def register(res: Response, data: RegisterAccountDTO):
     try:
         created_account = await account_service.create_account(data)
         access_token = await auth_service.set_token_cookies(res, created_account.accountId)
+        await email_service.send_verification_email(created_account, lang, access_token)
         created_account.accessToken = access_token
         return created_account
     except HTTPException as e:

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -6,7 +6,7 @@ import src.services.email_service as email_service
 from constants import NGINX_HOST
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
-from src.models.dto import RegisterAccountDTO
+from src.models.dto import AccountDTO, CredentialAccountDTO, RegisterAccountDTO
 from src.models.validators import validate_account_register
 
 # fastapi dev랑 run(prod)으로 실행시 각가 다르게 동작
@@ -75,15 +75,15 @@ async def verify_email(res: Response, token: str, lang: str = Query("en")):
 
 # TODO: data validation: username, password
 @router.post("/login", status_code=status.HTTP_200_OK, response_model=None)
-async def login(res: Response, data: dict) -> dict:
+async def login(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     try:
         print("login route")
         print(data)
-        username, password = data.values()
-        return await auth_service.authenticate(res, username, password)
+        return await auth_service.authenticate(res, data)
     except HTTPException as e:
         return JSONResponse(status_code=e.status_code, content={"code": "INVALID_LOGIN"})
-    except Exception:
+    except Exception as e:
+        print("e2", e)
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"code": "GENERAL_ERROR"}
         )

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -77,11 +77,9 @@ async def verify_email(res: Response, token: str, lang: str = Query("en")):
 @router.post("/login", status_code=status.HTTP_200_OK, response_model=None)
 async def login(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     try:
-        print("login route")
-        print(data)
         return await auth_service.authenticate(res, data)
     except HTTPException as e:
-        return JSONResponse(status_code=e.status_code, content={"code": "INVALID_LOGIN"})
+        return JSONResponse(status_code=e.status_code, content=e.detail)
     except Exception as e:
         print("e2", e)
         return JSONResponse(

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -4,9 +4,10 @@ import src.services.account_service as account_service
 import src.services.auth_service as auth_service
 import src.services.email_service as email_service
 from constants import NGINX_HOST
-from fastapi import APIRouter, Cookie, HTTPException, Query, Response, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Response, status
 from fastapi.responses import JSONResponse, RedirectResponse
 from src.models.dto import RegisterAccountDTO
+from src.models.validators import validate_account_register
 
 # fastapi dev랑 run(prod)으로 실행시 각가 다르게 동작
 router = APIRouter(
@@ -34,7 +35,11 @@ router = APIRouter(
 # pydantic validator 안 쓸시 response_model=None 지정 필수
 # TODO: data validation: username, email, password
 @router.post("/register", status_code=status.HTTP_201_CREATED, response_model=None)
-async def register(res: Response, data: RegisterAccountDTO, lang: str = Query("en")):
+async def register(
+    res: Response,
+    data: RegisterAccountDTO = Depends(validate_account_register),
+    lang: str = Query("en"),
+):
     """
     Register a new user account.
 

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -110,7 +110,7 @@ async def forgot_password(data: dict, lang: str = Query("en")) -> None:
     account = await account_service.get_account_by_email(email)
     if not account:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Account not found")
-    account_id = account["account_id"]
+    account_id = account.accountId
     token_info = auth_service.create_access_token(account_id, timedelta(hours=24))
     await email_service.send_password_reset_email({"email": email}, lang, token_info["accessToken"])
 

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -35,7 +35,7 @@ async def register(
     """
     try:
         created_account = await account_service.create_account(data)
-        access_token = await auth_service.set_token_cookies(res, created_account.accountId)
+        access_token = await auth_service.set_token_cookies(res, created_account.account_id)
         await email_service.send_verification_email(created_account, lang, access_token)
         created_account.access_token = access_token
         return created_account
@@ -60,7 +60,7 @@ async def request_email(res: Response, data: dict, lang: str = Query("en")):
     )
 
     return {
-        "accountId": account_id,
+        "account_id": account_id,
         "username": username,
         "email": email,
         "accessToken": access_token,
@@ -108,7 +108,7 @@ async def forgot_password(data: dict, lang: str = Query("en")) -> None:
     account = await account_service.get_account_by_email(email)
     if not account:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Account not found")
-    account_id = account.accountId
+    account_id = account.account_id
     token_info = auth_service.create_access_token(account_id, timedelta(hours=24))
     await email_service.send_password_reset_email({"email": email}, lang, token_info["access_token"])
 
@@ -130,7 +130,7 @@ async def reset_password(res: Response, token: str, lang: str = Query("en")) -> 
         # example
         redirect_url = f"{NGINX_HOST}/{lang}/auth/forgot-password"
         return RedirectResponse(url=redirect_url, headers=res.headers)
-    account_id = payload["accountId"]
+    account_id = payload["account_id"]
     await auth_service.set_token_cookies(res, account_id)
     redirect_url = f"{NGINX_HOST}/{lang}/auth/reset-password"
     return RedirectResponse(url=redirect_url, headers=res.headers)

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -40,7 +40,7 @@ async def register(
         created_account.accessToken = access_token
         return created_account
     except HTTPException as e:
-        return JSONResponse(status_code=e.status_code, content=e.detail)
+        return JSONResponse(status_code=e.status_code, content={"code": e.detail})
     except Exception:
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"code": "GENERAL_ERROR"}

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -16,22 +16,6 @@ router = APIRouter(
 )
 
 
-# # TODO: data validation: username, password
-# @router.post("/login", status_code=status.HTTP_200_OK, response_model=None)
-# async def login(res: Response, data: dict) -> dict:
-#     try:
-#         print("login route")
-#         print(data)
-#         username, password = data.values()
-#         return await auth_service.authenticate(res, username, password)
-#     except HTTPException as e:
-#         return JSONResponse(status_code=e.status_code, content={"code": "INVALID_LOGIN"})
-#     except Exception:
-#         return JSONResponse(
-#             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"code": "GENERAL_ERROR"}
-#         )
-
-
 # pydantic validator 안 쓸시 response_model=None 지정 필수
 # TODO: data validation: username, email, password
 @router.post("/register", status_code=status.HTTP_201_CREATED, response_model=None)
@@ -57,6 +41,8 @@ async def register(
         created_account.accessToken = access_token
         return created_account
     except HTTPException as e:
+        if e.status_code == status.HTTP_409_CONFLICT:
+            return JSONResponse(status_code=e.status_code, content=e.detail)
         return JSONResponse(status_code=e.status_code, content={"code": "INVALID_LOGIN"})
     except Exception:
         return JSONResponse(

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -37,7 +37,7 @@ async def register(
         created_account = await account_service.create_account(data)
         access_token = await auth_service.set_token_cookies(res, created_account.accountId)
         await email_service.send_verification_email(created_account, lang, access_token)
-        created_account.accessToken = access_token
+        created_account.access_token = access_token
         return created_account
     except HTTPException as e:
         return JSONResponse(status_code=e.status_code, content={"code": e.detail})
@@ -88,9 +88,9 @@ async def login(res: Response, data: CredentialAccountDTO) -> AccountDTO:
 
 
 @router.delete("/logout", status_code=status.HTTP_200_OK, response_model=None)
-async def logout(res: Response, accessToken: str = Cookie(None)):
-    print("logout():", accessToken)
-    return await auth_service.logout(res, accessToken)
+async def logout(res: Response, access_token: str = Cookie(None)):
+    print("logout():", access_token)
+    return await auth_service.logout(res, access_token)
 
 
 @router.post("/refresh", status_code=status.HTTP_200_OK, response_model=None)
@@ -110,7 +110,7 @@ async def forgot_password(data: dict, lang: str = Query("en")) -> None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Account not found")
     account_id = account.accountId
     token_info = auth_service.create_access_token(account_id, timedelta(hours=24))
-    await email_service.send_password_reset_email({"email": email}, lang, token_info["accessToken"])
+    await email_service.send_password_reset_email({"email": email}, lang, token_info["access_token"])
 
 
 @router.get("/reset-password", status_code=status.HTTP_200_OK, response_model=None)

--- a/back-fastapi/src/middlewares/token_required.py
+++ b/back-fastapi/src/middlewares/token_required.py
@@ -20,7 +20,7 @@ def token_required(redirect_url: str = None):
                     cookie.split("=")[0]: cookie.split("=")[1]
                     for cookie in cookie_header.split("; ")
                 }
-                token = cookies.get("accessToken")
+                token = cookies.get("access_token")
             print("token_required() token:", token)
 
             if token is None:

--- a/back-fastapi/src/middlewares/token_required.py
+++ b/back-fastapi/src/middlewares/token_required.py
@@ -41,7 +41,7 @@ def token_required(redirect_url: str = None):
                     raise HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
                     )
-            kwargs["data"]["account_id"] = payload["accountId"]
+            kwargs["data"]["account_id"] = payload["account_id"]
             return await func(req, *args, **kwargs)
 
         return wrapper

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -7,11 +7,11 @@ from constants import AccountStatus
 
 @dataclass
 class AccountDTO:
-    status: Optional[AccountStatus] = None
-    created_at: Optional[datetime] = None
-    accountId: Optional[int] = None
+    account_id: Optional[int] = None
     username: Optional[str] = None
     email: Optional[str] = None
+    status: Optional[AccountStatus] = None
+    created_at: Optional[datetime] = None
     password: Optional[str] = None
     google_id: Optional[str] = None
     intra42_id: Optional[str] = None
@@ -47,7 +47,7 @@ class AccountDTO:
     def from_dict(cls, data: Dict[str, Any]) -> "AccountDTO":
         def map_account_fields(db_record: Dict[str, Any]) -> Dict[str, Any]:
             mapping = {
-                "account_id": "accountId",
+                "account_id": "account_id",
                 "username": "username",
                 "email": "email",
                 "password": "password",
@@ -88,7 +88,7 @@ class AccountDTO:
 #     email: str
 #     status: Optional[AccountStatus]
 #     password: Optional[str]
-#     accountId: Optional[int]
+#     account_id: Optional[int]
 
 
 @dataclass
@@ -97,7 +97,7 @@ class RegisterAccountDTO:
     email: str
     password: Optional[str] = None
     status: Optional[AccountStatus] = None
-    accountId: Optional[int] = None
+    account_id: Optional[int] = None
     access_token: Optional[str] = None
 
 

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -29,14 +29,26 @@ class AccountDTO:
 
     def __post_init__(self):
         # Remove attributes with None values after initialization
-        to_remove = [key for key, value in self.__dict__.items() if value is None]
-        for key in to_remove:
-            delattr(self, key)
+        for key in list(self.__dict__.keys()):
+            if getattr(self, key) is None:
+                delattr(self, key)
 
     def __repr__(self):
         # Custom __repr__ to exclude None attributes when printing
-        attrs = ", ".join(f"{k}={v!r}" for k, v in self.__dict__.items())
-        return f"{self.__class__.__name__}({attrs})"
+        cls = self.__class__.__name__
+        attrs = {k: v for k, v in self.__dict__.items() if v is not None}
+        attrs_str = ", ".join(f"{key}={value!r}" for key, value in attrs.items())
+        return f"{cls}({attrs_str})"
+
+
+# @dataclass
+# class RegisterAccountDTO(AccountDTO):
+#     # Override the init method to exclude unwanted fields
+#     username: str
+#     email: str
+#     status: Optional[AccountStatus]
+#     password: Optional[str]
+#     accountId: Optional[int]
 
 
 @dataclass

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from constants import AccountStatus
 
@@ -42,6 +42,43 @@ class AccountDTO:
         attrs = {k: v for k, v in self.__dict__.items() if v is not None}
         attrs_str = ", ".join(f"{key}={value!r}" for key, value in attrs.items())
         return f"{cls}({attrs_str})"
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AccountDTO":
+        def map_account_fields(db_record: Dict[str, Any]) -> Dict[str, Any]:
+            mapping = {
+                "account_id": "accountId",
+                "username": "username",
+                "email": "email",
+                "password": "password",
+                "google_id": "google_id",
+                "intra42_id": "intra42_id",
+                "github_id": "github_id",
+                "refresh_token": "refreshToken",
+                "google_access_token": "google_access_token",
+                "google_refresh_token": "google_refresh_token",
+                "github_access_token": "github_access_token",
+                "github_refresh_token": "github_refresh_token",
+                "intra42_access_token": "intra42_access_token",
+                "intra42_refresh_token": "intra42_refresh_token",
+                "status": "status",
+                "created_at": "created_at",
+                "last_modified_at": "last_modified_at",
+                "deleted_at": "deleted_at",
+                "access_token": "accessToken",
+            }
+
+            return {mapping.get(k, k): v for k, v in db_record.items()}
+
+        # Optionally map database fields to DTO fields
+        mapped_data = map_account_fields(data)
+        # Handle datetime fields if they are strings or need conversion
+        for field_name, field_type in cls.__annotations__.items():
+            if field_type is Optional[datetime] and field_name in mapped_data:
+                if isinstance(mapped_data[field_name], str):
+                    # Convert string to datetime
+                    mapped_data[field_name] = datetime.fromisoformat(mapped_data[field_name])
+        return cls(**mapped_data)
 
 
 # @dataclass

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -18,8 +18,8 @@ class AccountDTO:
     github_id: Optional[str] = None
     last_modified_at: Optional[datetime] = None
     deleted_at: Optional[datetime] = None
-    access_token: Optional[str] = None
-    refresh_token: Optional[str] = None
+    accessToken: Optional[str] = None
+    refreshToken: Optional[str] = None
     google_access_token: Optional[str] = None
     google_refresh_token: Optional[str] = None
     github_access_token: Optional[str] = None

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -29,9 +29,12 @@ class AccountDTO:
 
     def __post_init__(self):
         # Remove attributes with None values after initialization
-        for key in list(self.__dict__.keys()):
-            if getattr(self, key) is None:
-                delattr(self, key)
+        keys_to_remove = [key for key, value in self.__dict__.items() if value is None]
+        for key in keys_to_remove:
+            delattr(self, key)
+
+    def to_dict(self):
+        return {k: v for k, v in self.__dict__.items() if v is not None}
 
     def __repr__(self):
         # Custom __repr__ to exclude None attributes when printing

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -1,11 +1,56 @@
-class CreateUser:
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from constants import AccountStatus
+
+
+@dataclass
+class AccountDTO:
+    status: Optional[AccountStatus] = None
+    created_at: Optional[datetime] = None
+    accountId: Optional[int] = None
+    username: Optional[str] = None
+    email: Optional[str] = None
+    password: Optional[str] = None
+    google_id: Optional[str] = None
+    intra42_id: Optional[str] = None
+    github_id: Optional[str] = None
+    last_modified_at: Optional[datetime] = None
+    deleted_at: Optional[datetime] = None
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    google_access_token: Optional[str] = None
+    google_refresh_token: Optional[str] = None
+    github_access_token: Optional[str] = None
+    github_refresh_token: Optional[str] = None
+    intra42_access_token: Optional[str] = None
+    intra42_refresh_token: Optional[str] = None
+
+    def __post_init__(self):
+        # Remove attributes with None values after initialization
+        to_remove = [key for key, value in self.__dict__.items() if value is None]
+        for key in to_remove:
+            delattr(self, key)
+
+    def __repr__(self):
+        # Custom __repr__ to exclude None attributes when printing
+        attrs = ", ".join(f"{k}={v!r}" for k, v in self.__dict__.items())
+        return f"{self.__class__.__name__}({attrs})"
+
+
+@dataclass
+class RegisterAccountDTO:
+    # Override the init method to exclude unwanted fields
     username: str
     email: str
-    password: str
+    password: Optional[str] = None
+    status: Optional[AccountStatus] = None
+    accountId: Optional[int] = None
+    accessToken: Optional[str] = None
 
 
-# class GetUser():
-#     id: int
-#     firstname: str
-#     lastname: str
-#     email: str
+# @dataclass
+# class DetailedAccountDTO(AccountDTO):
+#     first_name: str
+#     last_name: str

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -19,7 +19,7 @@ class AccountDTO:
     last_modified_at: Optional[datetime] = None
     deleted_at: Optional[datetime] = None
     access_token: Optional[str] = None
-    refreshToken: Optional[str] = None
+    refresh_token: Optional[str] = None
     google_access_token: Optional[str] = None
     google_refresh_token: Optional[str] = None
     github_access_token: Optional[str] = None
@@ -54,7 +54,7 @@ class AccountDTO:
                 "google_id": "google_id",
                 "intra42_id": "intra42_id",
                 "github_id": "github_id",
-                "refresh_token": "refreshToken",
+                "refresh_token": "refresh_token",
                 "google_access_token": "google_access_token",
                 "google_refresh_token": "google_refresh_token",
                 "github_access_token": "github_access_token",

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -18,7 +18,7 @@ class AccountDTO:
     github_id: Optional[str] = None
     last_modified_at: Optional[datetime] = None
     deleted_at: Optional[datetime] = None
-    accessToken: Optional[str] = None
+    access_token: Optional[str] = None
     refreshToken: Optional[str] = None
     google_access_token: Optional[str] = None
     google_refresh_token: Optional[str] = None
@@ -65,7 +65,7 @@ class AccountDTO:
                 "created_at": "created_at",
                 "last_modified_at": "last_modified_at",
                 "deleted_at": "deleted_at",
-                "access_token": "accessToken",
+                "access_token": "access_token",
             }
 
             return {mapping.get(k, k): v for k, v in db_record.items()}
@@ -98,7 +98,7 @@ class RegisterAccountDTO:
     password: Optional[str] = None
     status: Optional[AccountStatus] = None
     accountId: Optional[int] = None
-    accessToken: Optional[str] = None
+    access_token: Optional[str] = None
 
 
 @dataclass

--- a/back-fastapi/src/models/dto.py
+++ b/back-fastapi/src/models/dto.py
@@ -53,13 +53,18 @@ class AccountDTO:
 
 @dataclass
 class RegisterAccountDTO:
-    # Override the init method to exclude unwanted fields
     username: str
     email: str
     password: Optional[str] = None
     status: Optional[AccountStatus] = None
     accountId: Optional[int] = None
     accessToken: Optional[str] = None
+
+
+@dataclass
+class CredentialAccountDTO(AccountDTO):
+    username: str
+    password: str
 
 
 # @dataclass

--- a/back-fastapi/src/models/validators.py
+++ b/back-fastapi/src/models/validators.py
@@ -1,0 +1,95 @@
+import re
+
+from constants import DEFAULT_MAX, DEFAULT_MIN
+from fastapi import HTTPException
+
+from src.models.dto import RegisterAccountDTO
+
+
+def validate_string_field(value: str, field_name: str, min_length: int, max_length: int) -> None:
+    """
+    Reusable validation function for string fields.
+
+    Args:
+        value (str): The value of the field to validate.
+        field_name (str): The name of the field (e.g., 'username', 'email').
+        min_length (int): The minimum length for the field.
+        max_length (int): The maximum length for the field.
+
+    Raises:
+        HTTPException: If validation fails.
+    """
+    if len(value) == 0:
+        raise HTTPException(status_code=400, detail=f"{field_name} is required")
+    elif len(value) < min_length:
+        raise HTTPException(
+            status_code=400, detail=f"{field_name} must be at least {min_length} characters long"
+        )
+    elif len(value) > max_length:
+        raise HTTPException(
+            status_code=400, detail=f"{field_name} must be less than {max_length} characters long"
+        )
+
+
+async def validate_email(email: str) -> None:
+    re_pattern = r"^[\w.-]+@[a-zA-Z\d.-]+\.[a-zA-Z]{2,}$"  # Updated regex to match JS pattern
+
+    # maximum email address is set 50 chars on DB.
+    validate_string_field(email, "email", DEFAULT_MIN, DEFAULT_MAX)
+    if not re.match(re_pattern, email):
+        raise HTTPException(status_code=400, detail="Invalid email format")
+
+    # if option and option.get("prev_email") == email:
+    #     return  # Email hasn't changed
+
+    # # Simulate a database check for an existing email
+    # user_exists = False  # Change this as per your query logic
+    # if user_exists:
+    #     raise HTTPException(status_code=400, detail="Email is already taken")
+
+
+def validate_username(username: str) -> None:
+    validate_string_field(username, "username", DEFAULT_MIN, DEFAULT_MAX)
+
+
+async def validate_password(password: str) -> None:
+    re_pattern = r"(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+])[A-Za-z\d!@#$%^&*()_+]{8,}"
+
+    if len(password) == 0:
+        raise HTTPException(status_code=400, detail="password is required")
+    # didn't use validate_string_field as regex handles min
+    if not re.match(re_pattern, password):
+        raise HTTPException(
+            status_code=400,
+            detail="Password must be at least 8 characters long and include an uppercase letter,"
+            + " a lowercase letter, a digit, and a special character.",
+        )
+
+
+# def validate_languages(languages: List[str]) -> None:
+#     if len(languages) == 0:
+#         raise HTTPException(status_code=400, detail="Languages are required")
+#     elif len(languages) > 3:
+#         raise HTTPException(status_code=400, detail="You can specify at most 3 languages")
+
+
+# def validate_biography(biography: str) -> None:
+#     if len(biography) == 0:
+#         raise HTTPException(status_code=400, detail="Biography is required")
+#     elif len(biography) > 150:
+#         raise HTTPException(status_code=400, detail="Biography is too long")
+
+
+# def validate_birthdate(birthdate: str) -> None:
+#     age = AgeCalculator.get_age(datetime.strptime(birthdate, "%Y-%m-%d"))
+#     if age < 18:
+#         raise HTTPException(status_code=400, detail="You must be at least 18 years old")
+
+
+def validate_account_register(data: RegisterAccountDTO) -> RegisterAccountDTO:
+    validate_email(data.email)
+    # need to choose
+    # validate_username(data.username)
+    validate_string_field(data.username, "username", DEFAULT_MIN, DEFAULT_MAX)
+    validate_password(data.password)
+    return data

--- a/back-fastapi/src/models/validators.py
+++ b/back-fastapi/src/models/validators.py
@@ -31,11 +31,11 @@ def validate_string_field(value: str, field_name: str, min_length: int, max_leng
         )
 
 
-async def validate_email(email: str) -> None:
+def validate_email(email: str) -> None:
     re_pattern = r"^[\w.-]+@[a-zA-Z\d.-]+\.[a-zA-Z]{2,}$"  # Updated regex to match JS pattern
 
     # maximum email address is set 50 chars on DB.
-    validate_string_field(email, "email", DEFAULT_MIN, DEFAULT_MAX)
+    validate_string_field(email, "email", DEFAULT_MIN, 50)
     if not re.match(re_pattern, email):
         raise HTTPException(status_code=400, detail="Invalid email format")
 
@@ -52,7 +52,7 @@ def validate_username(username: str) -> None:
     validate_string_field(username, "username", DEFAULT_MIN, DEFAULT_MAX)
 
 
-async def validate_password(password: str) -> None:
+def validate_password(password: str) -> None:
     re_pattern = r"(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+])[A-Za-z\d!@#$%^&*()_+]{8,}"
 
     if len(password) == 0:

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -3,6 +3,7 @@ from typing import Optional
 from aiomysql import DictCursor
 from fastapi import HTTPException, status
 from src.models.db import get_db_connection
+from src.models.dto import AccountDTO
 
 
 async def check(username: str, email: str) -> None:
@@ -127,15 +128,14 @@ async def get_by_username(username: str) -> Optional[dict]:
             )
 
 
-async def get_by_email(email: str) -> Optional[dict]:
+async def get_by_email(email: str) -> Optional[AccountDTO]:
     async with get_db_connection() as connection, connection.cursor(DictCursor) as cursor:
         try:
             print("get_by_email():", email)
             await cursor.execute("SELECT * FROM account WHERE email = %s", (email,))
             account = await cursor.fetchone()
-            # print("account: ", account)
             if account:
-                return dict(account)
+                return AccountDTO.from_dict(dict(account))
             return None
         except Exception as e:
             print(e)

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -145,16 +145,18 @@ async def get_by_email(email: str) -> Optional[AccountDTO]:
             )
 
 
-async def authenticate(username: str, hashed_password: str) -> Optional[dict]:
+async def authenticate(username: str, hashed_password: str) -> Optional[AccountDTO]:
     async with get_db_connection() as connection, connection.cursor(DictCursor) as cursor:
         try:
             await cursor.execute(
-                "SELECT account_id, username FROM account WHERE username = %s AND password = %s",
+                "SELECT account_id, username, status FROM account"
+                + " WHERE username = %s AND password = %s",
                 (username, hashed_password),
             )
             account = await cursor.fetchone()
+            print("account", account)
             if account:
-                return dict(account)
+                return AccountDTO.from_dict(dict(account))
             return None
         except Exception as e:
             print(e)

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -12,14 +12,14 @@ async def check(username: str, email: str) -> None:
         if rows > 0:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Account already exists",
+                detail={"code": "USERNAME_ALREADY_EXISTS"},
             )
         # check by email
         rows = await cursor.execute("SELECT username FROM account WHERE email = %s", (email,))
         if rows > 0:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="Account already exists",
+                detail={"code": "EMAIL_ALREADY_EXISTS"},
             )
 
 

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -13,14 +13,14 @@ async def check(username: str, email: str) -> None:
         if rows > 0:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={"code": "USERNAME_ALREADY_EXISTS"},
+                detail="USERNAME_ALREADY_EXISTS",
             )
         # check by email
         rows = await cursor.execute("SELECT username FROM account WHERE email = %s", (email,))
         if rows > 0:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={"code": "EMAIL_ALREADY_EXISTS"},
+                detail="EMAIL_ALREADY_EXISTS",
             )
 
 

--- a/back-fastapi/src/repositories/account_repository.py
+++ b/back-fastapi/src/repositories/account_repository.py
@@ -94,14 +94,14 @@ async def update_password(account_id: int, hashed_password: str) -> None:
             )
 
 
-async def get_by_id(account_id: int) -> Optional[dict]:
+async def get_by_id(account_id: int) -> Optional[AccountDTO]:
     async with get_db_connection() as connection, connection.cursor(DictCursor) as cursor:
         try:
             await cursor.execute("SELECT * FROM account WHERE account_id = %s", (account_id,))
             account = await cursor.fetchone()
             # print("account: ", account)
             if account:
-                return dict(account)
+                return AccountDTO.from_dict(dict(account))
             return None
         except Exception as e:
             print(e)
@@ -111,14 +111,14 @@ async def get_by_id(account_id: int) -> Optional[dict]:
             )
 
 
-async def get_by_username(username: str) -> Optional[dict]:
+async def get_by_username(username: str) -> Optional[AccountDTO]:
     async with get_db_connection() as connection, connection.cursor(DictCursor) as cursor:
         try:
             await cursor.execute("SELECT * FROM account WHERE username = %s", (username,))
             account = await cursor.fetchone()
             # print("account: ", account)
             if account:
-                return dict(account)
+                return AccountDTO.from_dict(dict(account))
             return None
         except Exception as e:
             print(e)

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -6,24 +6,25 @@ from constants import AccountStatus
 from fastapi import HTTPException, status
 from src.models.dto import RegisterAccountDTO
 
-# async def check_account(username: str, email: str) -> None:
-#     """
-#     Check if an account already exists for the given username or email.
 
-#     Args:
-#         username (str): The username to check.
-#         email (str): The email to check.
+async def check_account(username: str, email: str) -> None:
+    """
+    Check if an account already exists for the given username or email.
 
-#     Raises:
-#         HTTPException: If the username or email already exists in the database
-#                         with a 409 Conflict status code.
-#     """
-#     if not (username or email):
-#         raise HTTPException(
-#             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-#             detail="All fields are required",
-#         )
-#     await account_repository.check(username, email)
+    Args:
+        username (str): The username to check.
+        email (str): The email to check.
+
+    Raises:
+        HTTPException: If the username or email already exists in the database
+                        with a 409 Conflict status code.
+    """
+    if not (username or email):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="All fields are required",
+        )
+    await account_repository.check(username, email)
 
 
 async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
@@ -42,12 +43,7 @@ async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
         account_id (int): Created account id
     """
     print("create_account(): ", data.username, data.email, data.password)
-    # await check_accoun0t(username, email)
-    # if not password:
-    #     raise HTTPException(
-    #         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-    #         detail="Password can not be empty",
-    #     )
+    await check_account(data.username, data.email)
     hashed_password = auth_service.hash_password(data.password)
     account_id = await account_repository.create(
         data.username, data.email, hashed_password, AccountStatus.PENDING_VERIFICATION.value

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -7,26 +7,6 @@ from fastapi import HTTPException, status
 from src.models.dto import RegisterAccountDTO
 
 
-async def check_account(username: str, email: str) -> None:
-    """
-    Check if an account already exists for the given username or email.
-
-    Args:
-        username (str): The username to check.
-        email (str): The email to check.
-
-    Raises:
-        HTTPException: If the username or email already exists in the database
-                        with a 409 Conflict status code.
-    """
-    if not (username or email):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="All fields are required",
-        )
-    await account_repository.check(username, email)
-
-
 async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
     """
     Create a new account after checking for existing username and email.
@@ -43,7 +23,7 @@ async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
         account_id (int): Created account id
     """
     print("create_account(): ", data.username, data.email, data.password)
-    await check_account(data.username, data.email)
+    await account_repository.check(data.username, data.email)
     hashed_password = auth_service.hash_password(data.password)
     account_id = await account_repository.create(
         data.username, data.email, hashed_password, AccountStatus.PENDING_VERIFICATION.value

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -30,7 +30,7 @@ async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
     )
 
     result = RegisterAccountDTO(
-        accountId=account_id,
+        account_id=account_id,
         status=AccountStatus.PENDING_VERIFICATION.value,
         username=data.username,
         email=data.email,

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -4,29 +4,29 @@ import src.repositories.account_repository as account_repository
 import src.services.auth_service as auth_service
 from constants import AccountStatus
 from fastapi import HTTPException, status
+from src.models.dto import RegisterAccountDTO
+
+# async def check_account(username: str, email: str) -> None:
+#     """
+#     Check if an account already exists for the given username or email.
+
+#     Args:
+#         username (str): The username to check.
+#         email (str): The email to check.
+
+#     Raises:
+#         HTTPException: If the username or email already exists in the database
+#                         with a 409 Conflict status code.
+#     """
+#     if not (username or email):
+#         raise HTTPException(
+#             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+#             detail="All fields are required",
+#         )
+#     await account_repository.check(username, email)
 
 
-async def check_account(username: str, email: str) -> None:
-    """
-    Check if an account already exists for the given username or email.
-
-    Args:
-        username (str): The username to check.
-        email (str): The email to check.
-
-    Raises:
-        HTTPException: If the username or email already exists in the database
-                        with a 409 Conflict status code.
-    """
-    if not (username or email):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="All fields are required",
-        )
-    await account_repository.check(username, email)
-
-
-async def create_account(username: str, email: str, password: str) -> int:
+async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
     """
     Create a new account after checking for existing username and email.
 
@@ -41,20 +41,26 @@ async def create_account(username: str, email: str, password: str) -> int:
     Returns:
         account_id (int): Created account id
     """
-    print("create_account(): ", username, email, password)
-    await check_account(username, email)
-
-    if not password:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Password can not be empty",
-        )
-    hashed_password = auth_service.hash_password(password)
-    print("all passed", hashed_password)
-
-    return await account_repository.create(
-        username, email, hashed_password, AccountStatus.PENDING_VERIFICATION.value
+    print("create_account(): ", data.username, data.email, data.password)
+    # await check_accoun0t(username, email)
+    # if not password:
+    #     raise HTTPException(
+    #         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    #         detail="Password can not be empty",
+    #     )
+    hashed_password = auth_service.hash_password(data.password)
+    account_id = await account_repository.create(
+        data.username, data.email, hashed_password, AccountStatus.PENDING_VERIFICATION.value
     )
+
+    result = RegisterAccountDTO(
+        accountId=account_id,
+        status=AccountStatus.PENDING_VERIFICATION.value,
+        username=data.username,
+        email=data.email,
+        password=None,  # Exclude the password in the response for security reasons
+    )
+    return result
 
 
 async def update_account_status(account_id: int, account_status: str) -> None:

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -114,22 +114,6 @@ async def get_account_by_id(account_id: int) -> Optional[dict]:
     return await account_repository.get_by_id(account_id)
 
 
-async def get_account_by_username(username: str) -> Optional[dict]:
-    """
-    Retrieve an account by its username.
-
-    Args:
-        username (str): The username of the account to retrieve.
-
-    Returns:
-        Optional[dict]: A dictionary containing the account details or None if account not found.
-
-    Raises:
-        HTTPException: Any bad requests.
-    """
-    return await account_repository.get_by_username(username)
-
-
 async def get_account_by_email(email: str) -> Optional[AccountDTO]:
     """
     Retrieve an account by its email.

--- a/back-fastapi/src/services/account_service.py
+++ b/back-fastapi/src/services/account_service.py
@@ -4,7 +4,7 @@ import src.repositories.account_repository as account_repository
 import src.services.auth_service as auth_service
 from constants import AccountStatus
 from fastapi import HTTPException, status
-from src.models.dto import RegisterAccountDTO
+from src.models.dto import AccountDTO, RegisterAccountDTO
 
 
 async def create_account(data: RegisterAccountDTO) -> RegisterAccountDTO:
@@ -130,7 +130,7 @@ async def get_account_by_username(username: str) -> Optional[dict]:
     return await account_repository.get_by_username(username)
 
 
-async def get_account_by_email(email: str) -> Optional[dict]:
+async def get_account_by_email(email: str) -> Optional[AccountDTO]:
     """
     Retrieve an account by its email.
 

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -32,16 +32,18 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     account: AccountDTO = await account_repository.get_by_username(data.username)
     if not account:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail={"code": "INVALID_USER_CREDENTIALS"}
+            status_code=status.HTTP_400_BAD_REQUEST, detail={"code": "INVALID_LOGIN"}
         )
     hashed_password = account.password
     verified = verify_password(data.password, hashed_password)
     if verified is False:
-        HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_LOGIN"})
+        HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_USER_CREDENTIALS"}
+        )
     account: AccountDTO = await account_repository.authenticate(data.username, hashed_password)
     if not account:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_LOGIN"}
+            status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_USER_CREDENTIALS"}
         )
     account.accessToken = await set_token_cookies(res, account.accountId)
     if account.status == AccountStatus.OFFLINE.value:

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -48,7 +48,13 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     account_status = await account_service.get_account_status(account_id)
     if account_status == AccountStatus.OFFLINE.value:
         await account_service.update_account_status(account_id, AccountStatus.ONLINE.value)
-    return AccountDTO(accountId=account_id, username=data.username, access_token=access_token)
+        account_status = AccountStatus.ONLINE.value
+    return AccountDTO(
+        accountId=account_id,
+        username=data.username,
+        accessToken=access_token,
+        status=account_status,
+    )
 
 
 async def logout(res: Response, token: str):

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -29,10 +29,10 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 
 async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
-    account = await account_service.get_account_by_username(data.username)
+    account: AccountDTO = await account_repository.get_by_username(data.username)
     if not account:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid login credentials"
+            status_code=status.HTTP_400_BAD_REQUEST, detail={"code": "INVALID_USER_CREDENTIALS"}
         )
     hashed_password = account["password"]
     verified = verify_password(data.password, hashed_password)
@@ -43,7 +43,6 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_LOGIN"}
         )
-    print("account 2", account)
     account.accessToken = await set_token_cookies(res, account.accountId)
     if account.status == AccountStatus.OFFLINE.value:
         await account_service.update_account_status(account.accountId, AccountStatus.ONLINE.value)

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -132,7 +132,7 @@ def create_refresh_token(account_id: int, expire_delta: timedelta = None) -> str
         "expires": expire,
     }
 
-    return {"refreshToken": token, "options": cookie_options}
+    return {"refresh_token": token, "options": cookie_options}
 
 
 async def save_refresh_token(account_id: int, refresh_token: str) -> None:
@@ -156,14 +156,14 @@ async def set_token_cookies(res: Response, account_id: int) -> str:
             expires=access_token_info["options"]["expires"],
         )
         res.set_cookie(
-            key="refreshToken",
-            value=refresh_token_info["refreshToken"],
+            key="refresh_token",
+            value=refresh_token_info["refresh_token"],
             httponly=refresh_token_info["options"]["httponly"],
             secure=refresh_token_info["options"]["secure"],
             expires=refresh_token_info["options"]["expires"],
         )
 
-        await save_refresh_token(account_id, refresh_token_info["refreshToken"])
+        await save_refresh_token(account_id, refresh_token_info["refresh_token"])
     except Exception:
         raise HTTPException(
             detail="Error generating tokens",

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -34,7 +34,7 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail={"code": "INVALID_USER_CREDENTIALS"}
         )
-    hashed_password = account["password"]
+    hashed_password = account.password
     verified = verify_password(data.password, hashed_password)
     if verified is False:
         HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_LOGIN"})

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -54,7 +54,7 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
         username=data.username,
         accessToken=access_token,
         status=account_status,
-    )
+    ).to_dict()
 
 
 async def logout(res: Response, token: str):
@@ -67,8 +67,8 @@ async def logout(res: Response, token: str):
 
         await save_refresh_token(account_id, "")
         account_status = await account_service.get_account_status(account_id)
-        if account_status is AccountStatus.LOGIN.value:
-            await account_service.update_account_status(account_id, AccountStatus.LOGOUT.value)
+        if account_status is AccountStatus.ONLINE.value:
+            await account_service.update_account_status(account_id, AccountStatus.OFFLINE.value)
 
         res.delete_cookie(key="accessToken", domain=DOMAIN, httponly=True, path="/")
         res.delete_cookie(key="refreshToken", domain=DOMAIN, httponly=True, path="/")

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -32,7 +32,7 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     account: AccountDTO = await account_repository.get_by_username(data.username)
     if not account:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail={"code": "INVALID_LOGIN"}
+            status_code=status.HTTP_400_BAD_REQUEST, detail="INVALID_LOGIN"
         )
     hashed_password = account.password
     verified = verify_password(data.password, hashed_password)

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -43,7 +43,7 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
     account: AccountDTO = await account_repository.authenticate(data.username, hashed_password)
     if not account:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_USER_CREDENTIALS"}
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="INVALID_USER_CREDENTIALS"
         )
     account.access_token = await set_token_cookies(res, account.account_id)
     if account.status == AccountStatus.OFFLINE.value:

--- a/back-fastapi/src/services/auth_service.py
+++ b/back-fastapi/src/services/auth_service.py
@@ -45,9 +45,9 @@ async def authenticate(res: Response, data: CredentialAccountDTO) -> AccountDTO:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail={"code": "INVALID_USER_CREDENTIALS"}
         )
-    account.access_token = await set_token_cookies(res, account.accountId)
+    account.access_token = await set_token_cookies(res, account.account_id)
     if account.status == AccountStatus.OFFLINE.value:
-        await account_service.update_account_status(account.accountId, AccountStatus.ONLINE.value)
+        await account_service.update_account_status(account.account_id, AccountStatus.ONLINE.value)
     return account.to_dict()
 
 
@@ -57,7 +57,7 @@ async def logout(res: Response, token: str):
 
     try:
         payload = jwt.decode(token, JWT_SECRET)
-        account_id = payload["accountId"]
+        account_id = payload["account_id"]
 
         await save_refresh_token(account_id, "")
         account_status = await account_service.get_account_status(account_id)
@@ -78,7 +78,7 @@ async def refresh(res: Response, token: str) -> dict:
 
     try:
         payload = jwt.decode(token, JWT_SECRET)
-        account_id = payload["accountId"]
+        account_id = payload["account_id"]
 
         res.delete_cookie(key="access_token", domain=DOMAIN, httponly=True, path="/")
         res.delete_cookie(key="refresh_token", domain=DOMAIN, httponly=True, path="/")
@@ -116,7 +116,7 @@ def create_access_token(account_id: int, expire_delta: timedelta = None) -> str:
 
 
 def create_refresh_token(account_id: int, expire_delta: timedelta = None) -> str:
-    payload = {"accountId": account_id}
+    payload = {"account_id": account_id}
     if expire_delta:
         expire = datetime.now(timezone.utc) + expire_delta
     else:

--- a/back-fastapi/src/services/email_service.py
+++ b/back-fastapi/src/services/email_service.py
@@ -6,12 +6,12 @@ from aiosmtplib import SMTP
 from constants import BACK_HOST, GMAIL_ID, GMAIL_PASSWORD, NGINX_HOST, AccountStatus
 from fastapi import HTTPException, Response, status
 from fastapi.responses import RedirectResponse
+from src.models.dto import RegisterAccountDTO
 
 
 # TODO: data validation
 # TODO: exception handling
-async def send_verification_email(data: dict, lang: str, token: str) -> None:
-    account_id, username, email = data.values()
+async def send_verification_email(data: RegisterAccountDTO, lang: str, token: str) -> None:
     print("send_verification_email():", data, lang)
 
     subject_template = {
@@ -20,8 +20,10 @@ async def send_verification_email(data: dict, lang: str, token: str) -> None:
     }
 
     html_template = {
-        "en": f'<a href="{BACK_HOST}/verify-email?token={token}&lang=en">Verify your email for username: {username}</a>',
-        "fr": f'<a href="{BACK_HOST}/verify-email?token={token}&lang=fr">Vérifiez votre email pour votre username: {username}</a>',
+        "en": f'<a href="{BACK_HOST}/verify-email?token={token}&lang=en">'
+        + f"Verify your email for username: {data.username}</a>",
+        "fr": f'<a href="{BACK_HOST}/verify-email?token={token}&lang=fr">'
+        + f"Vérifiez votre email pour votre username: {data.username}</a>",
     }
 
     subject = subject_template.get(lang, subject_template["en"])
@@ -29,7 +31,7 @@ async def send_verification_email(data: dict, lang: str, token: str) -> None:
 
     message = EmailMessage()
     message["From"] = GMAIL_ID
-    message["To"] = email
+    message["To"] = data.email
     message["Subject"] = subject
     message.set_content(html, subtype="html")
 

--- a/back-fastapi/src/services/email_service.py
+++ b/back-fastapi/src/services/email_service.py
@@ -56,7 +56,7 @@ async def verify_email(res: Response, token: str, lang: str):
         # example
         redirect_url = f"{NGINX_HOST}/{lang}/auth/request-email"
         return RedirectResponse(url=redirect_url, headers=res.headers)
-    account_id = payload["accountId"]
+    account_id = payload["account_id"]
 
     account = await account_service.get_account_by_id(account_id)
     # print("service verify_email() account:", account)

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -13,6 +13,7 @@ export const useAuth = () => {
 
   const doRegister = async (
     info: AccountData,
+    lang: string,
     socialLogin: Record<string, any> = {},
   ) => {
     try {
@@ -26,7 +27,7 @@ export const useAuth = () => {
         payload.socialInfo = socialLogin; // Dynamically add socialInfo field
       }
 
-      const { data } = await axios.post(`${endpoint}`, payload);
+      const { data } = await axios.post(`${endpoint}?lang=${lang}`, payload);
       // Set user data and trigger the refresh auth process
       console.log('doRegister data:', data);
       accountData.value = { ...accountData.value, ...data };

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -106,7 +106,7 @@ export const useAuth = () => {
       password: info.password,
     });
     try {
-      const profileResponse = await axios.get('/api/profile/', {
+      const profileResponse = await axios.get('/profile', {
         headers: { Authorization: `Bearer ${data.accessToken}` },
       });
 
@@ -125,9 +125,7 @@ export const useAuth = () => {
       //   }
       //   // Handle other status codes as necessary
     }
-    console.log('doLogin data:', data);
-    accountData.value = { ...accountData.value, ...data };
-    console.log('doLogin acconutData:', accountData.value);
+    accountData.value = data;
     startRefreshAuth();
   };
 

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -65,7 +65,7 @@ export const useAuth = () => {
         method: 'POST',
         headers: {
           ...cookie,
-          Authorization: `Bearer ${accountData.value.accessToken}`,
+          Authorization: `Bearer ${accountData.value.access_token}`,
         },
       });
       console.log('doRefreshTokenServer data:', data);
@@ -106,7 +106,7 @@ export const useAuth = () => {
     });
     try {
       const profileResponse = await axios.get('/profile', {
-        headers: { Authorization: `Bearer ${data.accessToken}` },
+        headers: { Authorization: `Bearer ${data.access_token}` },
       });
 
       console.log(profileResponse);

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -13,20 +13,20 @@ export const useAuth = () => {
 
   const doRegister = async (
     info: AccountData,
-    lang: string,
     socialLogin: Record<string, any> = {},
   ) => {
     try {
       let endpoint = '/register'; // Default to plain register
 
       const payload = { ...info } as Record<string, any>;
+      console.log('payload', payload);
       // If it's a social login, use the social registration endpoint
       if (Object.keys(socialLogin).length > 0) {
         endpoint = '/social-register';
         payload.socialInfo = socialLogin; // Dynamically add socialInfo field
       }
 
-      const { data } = await axios.post(`${endpoint}?lang=${lang}`, payload);
+      const { data } = await axios.post(`${endpoint}`, payload);
       // Set user data and trigger the refresh auth process
       console.log('doRegister data:', data);
       accountData.value = { ...accountData.value, ...data };

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -125,7 +125,9 @@ export const useAuth = () => {
       //   }
       //   // Handle other status codes as necessary
     }
+    console.log('data check', data);
     accountData.value = data;
+    console.log('account data check', accountData.value);
     startRefreshAuth();
   };
 

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -20,7 +20,6 @@ export const useAuth = () => {
       let endpoint = '/register'; // Default to plain register
 
       const payload = { ...info } as Record<string, any>;
-      console.log('payload', payload);
       // If it's a social login, use the social registration endpoint
       if (Object.keys(socialLogin).length > 0) {
         endpoint = '/social-register';
@@ -30,7 +29,7 @@ export const useAuth = () => {
       const { data } = await axios.post(`${endpoint}?lang=${lang}`, payload);
       // Set user data and trigger the refresh auth process
       console.log('doRegister data:', data);
-      accountData.value = { ...accountData.value, ...data };
+      accountData.value = data;
       console.log('doRegister acconutData:', accountData.value);
       startRefreshAuth();
 

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -57,7 +57,7 @@ export const useAuth = () => {
   };
 
   const doRefreshTokenServer = async () => {
-    if (accountData.value.accountId) return;
+    if (accountData.value.account_id) return;
 
     const cookie = useRequestHeaders(['cookie']);
     try {

--- a/front-nuxt/composables/useAxios.ts
+++ b/front-nuxt/composables/useAxios.ts
@@ -6,8 +6,8 @@ export const useAxios = () => {
   const api = axios.create({
     baseURL,
     headers: {
-      Authorization: accountData.value.accessToken
-        ? `Bearer ${accountData.value.accessToken}`
+      Authorization: accountData.value.access_token
+        ? `Bearer ${accountData.value.access_token}`
         : undefined,
     },
     withCredentials: true,

--- a/front-nuxt/pages/auth/register.vue
+++ b/front-nuxt/pages/auth/register.vue
@@ -178,8 +178,8 @@
       // if (token.value) {
       //   console.log('token check', token.value);
       // }
-      await doRegister(userInfo, locale.value, socialInfo);
-      await doRequestEmail(locale.value);
+      await doRegister(userInfo, socialInfo);
+      // await doRequestEmail(locale.value);
       await navigateTo({ path: localePath('auth-verify-email') });
     } catch (e) {
       if (e.response && e.response.data.code) {

--- a/front-nuxt/pages/auth/register.vue
+++ b/front-nuxt/pages/auth/register.vue
@@ -179,11 +179,10 @@
       //   console.log('token check', token.value);
       // }
       await doRegister(userInfo, socialInfo);
-      // await doRequestEmail(locale.value);
+      await doRequestEmail(locale.value);
       await navigateTo({ path: localePath('auth-verify-email') });
     } catch (e) {
       if (e.response && e.response.data.code) {
-        console.log('checker', e.response.data);
         errorGlobal.value = t(`Error.${e.response.data.code}`);
       } else {
         errorGlobal.value = t('Error.GENERAL_ERROR');

--- a/front-nuxt/plugins/01.init.ts
+++ b/front-nuxt/plugins/01.init.ts
@@ -6,16 +6,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   // Server-side specific logic
   if (ssrContext) {
-    accountData.value.accessToken = useCookie('accessToken').value as string;
-    if (accountData.value.accessToken && !accountData.value.email) {
+    accountData.value.access_token = useCookie('access_token').value as string;
+    if (accountData.value.access_token && !accountData.value.email) {
       await auth.doRefreshTokenServer();
     }
 
-    if (accountData.value.accessToken && !profileData.value) {
+    if (accountData.value.access_token && !profileData.value) {
       try {
         // Use $fetch to make an API call on the server-side
         profileData.value = await $fetch('/api/profile/', {
-          headers: { Authorization: `Bearer ${accountData.value.accessToken}` },
+          headers: { Authorization: `Bearer ${accountData.value.access_token}` },
         });
       } catch (error) {
         console.error('Error fetching profile data on server:', error);
@@ -26,9 +26,9 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   // Client-side specific logic
   if (!ssrContext) {
-    accountData.value.accessToken = useCookie('accessToken').value as string;
+    accountData.value.access_token = useCookie('access_token').value as string;
 
-    if (accountData.value.accessToken) {
+    if (accountData.value.access_token) {
       auth.doRefreshTokenClient();
       auth.startRefreshAuth();
 
@@ -37,7 +37,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
           // Use your API instance to fetch profile data
           const response = await axios.get('/api/profile/', {
             headers: {
-              Authorization: `Bearer ${accountData.value.accessToken}`,
+              Authorization: `Bearer ${accountData.value.access_token}`,
             },
           });
           profileData.value = response.data;

--- a/front-nuxt/stores/user.store.ts
+++ b/front-nuxt/stores/user.store.ts
@@ -5,7 +5,7 @@ export const useUserStore = defineStore('user', () => {
   const profileData = ref<ProfileData | null>(null);
   const refreshTokenIntervalId = ref();
 
-  const isLoggedIn = computed(() => !!accountData.value.accessToken);
+  const isLoggedIn = computed(() => !!accountData.value.access_token);
   const isEmailVerified = computed(() => {
     if (accountData.value.status === 'pending_verification') return false;
     else return true;

--- a/front-nuxt/types/index.ts
+++ b/front-nuxt/types/index.ts
@@ -1,5 +1,5 @@
 export interface AccountData {
-  accountId?: number;
+  account_id?: number;
   email?: string;
   status?: string;
   access_token?: string;

--- a/front-nuxt/types/index.ts
+++ b/front-nuxt/types/index.ts
@@ -2,7 +2,7 @@ export interface AccountData {
   accountId?: number;
   email?: string;
   status?: string;
-  accessToken?: string;
+  access_token?: string;
   google_id?: string;
   intra42_id?: string;
   github_id?: string;

--- a/miniconda_setup.sh
+++ b/miniconda_setup.sh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+
+if [ -d "/goinfre" ]; then
+  # Take action if $DIR exists. #
+  echo "setting MYPATH for school\n"
+  export MYPATH="/goinfre/$USER/miniconda3"
+else
+  echo "setting MYPATH for mac\n"
+  export MYPATH="/Users/$USER/Documents/miniconda3/"
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+	# For MAC
+	curl -LO "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+	sh Miniconda3-latest-MacOSX-x86_64.sh -b -p $MYPATH
+elif [[ "$(uname)" == "Linux" ]]; then
+	curl -LO "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+	sh Miniconda3-latest-Linux-x86_64.sh -b -p $MYPATH
+fi
+
+# For zsh
+$MYPATH/bin/conda init zsh
+$MYPATH/bin/conda config --set auto_activate_base false
+source ~/.zshrc
+

--- a/miniconda_setup.sh
+++ b/miniconda_setup.sh
@@ -23,3 +23,4 @@ $MYPATH/bin/conda init zsh
 $MYPATH/bin/conda config --set auto_activate_base false
 source ~/.zshrc
 
+conda create -n matcha-fastapi python=3.10


### PR DESCRIPTION
register 단계에서 사용할 DTO 클래스 RegisterAccountDTO 클래스를 만들었습니다
- `src/models/dto.py` 코드에도 나와 있지만 우선 AccountDTO (express 코드에서 그대로 가져옴)을 만들어 놓았습니다
  - 주석에 상속으로 만든 RegisterAccountDTO 가 있긴 한데, 디버깅으로 프린팅 할때 Optional로 지정된 attribute들이 전부 키에 있어 우선은 상속받지 않은 클래스로 코드를 적용했습니다. 주석 바꾸면 동작합니다 (대신 디버깅때 AccountDTO에 있는 attribue들이 전부 나옵니다)

- validator.py 코드를 만들어 놓았습니다. 
  - validator.py에서는 우선적으로 문자열에 대한 validaton만 진행 하도록 코드를 작성 하였습니다.
      - validation 에서 raise 하는 HTTPExceptions 에러들은 전부 문자열에 대한 validation 이라 JSONResponse code로 리턴하는 형식을 사용하지 않았습니다. swagger로 확인 해보세요 
  - DB를 확인해서 validation하는 작업들은 우선 `account_repository.check(data.username, data.email)` 함수 때문에  service 단계에서 확인 하도록 처리 해놓았습니다. 그대로 놔둬도 되고 분리 해도 됩니다
    - repository 에서 raise 하는 exception도 잘 처리되도록 controller 코드, error status 코드 수정 해놨으니 살펴보세요
  - Depends 를 사용하여 validation을 진행합니다. 
 
 
- CredentialAccountDTO 는 상속을 사용 해봤습니다.

- 로그인 단계에서 AccountDTO 를 만들어 줄때 값이 지정되지 않은 attribute들은 .to_dict() 함수를 통해서 attribute들을 지워주는 식으로 지정 해봤습니다. 좋은 방법인지는 모르겠는데 auth_service.py 코드 한번 살펴봐주세요.
-  `__post_init__` (__repr__는 프린트용) 단계에서 attribute를 지우는 방식 코드를 작성하긴 했는데 했는데 적용이 되는것 같진 않네요.
  
- 로그인/로그아웃 단계에서 AccountStatus 중  LOGIN, LOGOUT으로 설정 되어 있던 부분을 DB 값이랑 동일하게 가져가도록 OFFLINE / ONLINE으로 수정 해놨습니다 

- account_service 에서 account_repository 로 접근해 받아오는 몇몇 코드들을 지웠습니다. 리포지토리 패턴을 쓸거면 `get_account_Xxx`들은 필요 없어보입니다.

OAuth 코드 진행하면서 dto, validation 구조가 필요한 상황이라 우선 이 코드를 베이스로 Oauth 작업을 진행 해야 될듯 하니, 이 코드를 최대한 빠르게 머지 하고 dto 코드를 참고 하셔서 작업 하셔야될듯 합니다




close #55, #39