### PR TITLE
refactor: nginx proxy api

### DIFF
--- a/Dockerfile.back
+++ b/Dockerfile.back
@@ -8,5 +8,5 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 FROM dependencies AS development
 COPY ./back-fastapi /code/
-CMD ["uvicorn", "main:app", "--host", "back", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 EXPOSE $BACK_PORT

--- a/back-fastapi/main.py
+++ b/back-fastapi/main.py
@@ -1,8 +1,7 @@
-import aiomysql
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import FastAPI
 from src.controllers import account_controller, auth_controller, profile_controller
 from src.middlewares import cors_middleware
-from src.models.db import database, get_db_connection
+from src.models.db import database
 
 app = FastAPI()
 
@@ -22,16 +21,6 @@ async def shutdown_event():
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
-
-
-@app.get("/accounts/{account_id}")
-async def read_account(account_id: int, connection=Depends(get_db_connection)):
-    async with connection.cursor(aiomysql.DictCursor) as cursor:
-        await cursor.execute("SELECT * FROM account WHERE account_id = %s", (account_id,))
-        account = await cursor.fetchone()
-        if account is None:
-            raise HTTPException(detail="Account not found", status_code=status.HTTP_404_NOT_FOUND)
-        return account
 
 
 app.include_router(auth_controller.router)

--- a/back-fastapi/src/controllers/account_controller.py
+++ b/back-fastapi/src/controllers/account_controller.py
@@ -4,7 +4,7 @@ import src.services.account_service as account_service
 from fastapi import APIRouter, HTTPException, Request, status
 from src.middlewares.token_required import token_required
 
-router = APIRouter(tags=["Account"])
+router = APIRouter(prefix="/account", tags=["Account"])
 
 
 @router.get("/account/{account_id}", status_code=status.HTTP_200_OK, response_model=None)

--- a/back-fastapi/src/controllers/auth_controller.py
+++ b/back-fastapi/src/controllers/auth_controller.py
@@ -15,7 +15,7 @@ from src.models.validators import validate_account, validate_account_register
 
 # fastapi dev랑 run(prod)으로 실행시 각가 다르게 동작
 router = APIRouter(
-    # prefix="/auth",
+    prefix="/auth",
     tags=["Auth"]
 )
 

--- a/back-fastapi/src/middlewares/gaurd.py
+++ b/back-fastapi/src/middlewares/gaurd.py
@@ -1,0 +1,58 @@
+from functools import wraps
+from typing import Any, Callable
+
+import src.services.auth_service as auth_service
+from constants import NGINX_HOST
+from fastapi import HTTPException, Request, Response, status
+from fastapi.responses import RedirectResponse
+
+
+def gaurd(redirect_path: str = None):
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        print("gaurd() decorator", func.__annotations__)
+
+        @wraps(func)
+        async def wrapper(res: Response, req: Request, *args, **kwargs):
+            print("gaurd() wrapper", args, kwargs)
+            token = req.headers.get("Authorization")
+            print("gaurd() token:", token)
+            cookie_header = req.headers.get("cookie")
+            if cookie_header:
+                cookies = {
+                    cookie.split("=")[0]: cookie.split("=")[1]
+                    for cookie in cookie_header.split("; ")
+                }
+                token = cookies.get("access_token")
+            print("gaurd() token:", token)
+
+            if token is None:
+                if redirect_path is not None:
+                    return RedirectResponse(
+                        url=f"{NGINX_HOST}/{kwargs['lang']}/{redirect_path}", headers=req.headers
+                    )
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Token is required",
+                    )
+            if token.startswith("Bearer "):
+                token = token.split(" ")[1]
+            payload = auth_service.decode_token(token)
+
+            print("gaurd() payload:", payload)
+            # token 만료시
+            if payload is None:
+                if redirect_path is not None:
+                    return RedirectResponse(
+                        url=f"{NGINX_HOST}/{kwargs['lang']}/{redirect_path}", headers=req.headers
+                    )
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
+                    )
+            # kwargs["data"]["account_id"] = payload["account_id"]
+            return await func(res, req, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/back-fastapi/src/services/email_service.py
+++ b/back-fastapi/src/services/email_service.py
@@ -3,7 +3,7 @@ from email.message import EmailMessage
 import src.services.account_service as account_service
 import src.services.auth_service as auth_service
 from aiosmtplib import SMTP
-from constants import BACK_HOST, GMAIL_ID, GMAIL_PASSWORD, NGINX_HOST, AccountStatus
+from constants import GMAIL_ID, GMAIL_PASSWORD, NGINX_HOST, AccountStatus
 from fastapi import Response
 from fastapi.responses import RedirectResponse
 from src.models.dtos.account_dto import GeneralAccountDTO
@@ -20,9 +20,9 @@ async def send_verification_email(data: GeneralAccountDTO, lang: str, token: str
     }
 
     html_template = {
-        "en": f'<a href="{BACK_HOST}/verify-email?token={token}&lang=en">'
+        "en": f'<a href="{NGINX_HOST}/api/verify-email?token={token}&lang=en">'
         + f"Verify your email for username: {data.username}</a>",
-        "fr": f'<a href="{BACK_HOST}/verify-email?token={token}&lang=fr">'
+        "fr": f'<a href="{NGINX_HOST}/api/verify-email?token={token}&lang=fr">'
         + f"Vérifiez votre email pour votre username: {data.username}</a>",
     }
 
@@ -73,8 +73,8 @@ async def send_password_reset_email(data: dict, lang: str, token: str) -> None:
     }
 
     html_template = {
-        "en": f'<a href="{BACK_HOST}/reset-password?token={token}&lang=en">Password reset for Matcha</a>',
-        "fr": f'<a href="{BACK_HOST}/reset-password?token={token}&lang=fr">Reinitialisation du mot de passe pour Matcha</a>',
+        "en": f'<a href="{NGINX_HOST}/api/reset-password?token={token}&lang=en">Password reset for Matcha</a>',
+        "fr": f'<a href="{NGINX_HOST}/api/reset-password?token={token}&lang=fr">Reinitialisation du mot de passe pour Matcha</a>',
     }
 
     subject = subject_template.get(lang, subject_template["en"])

--- a/front-nuxt/components/MenuSelector.vue
+++ b/front-nuxt/components/MenuSelector.vue
@@ -84,12 +84,11 @@
     showDropdown.value = false;
   });
 
-  const axios = useAxios();
   const { doLogout } = useAuth();
 
   const handleAction = async (value) => {
     if (value === 'menu-logout') {
-      await doLogout(axios);
+      await doLogout();
       await navigateTo({ path: localePath('index') });
     }
   };

--- a/front-nuxt/composables/useAccount.ts
+++ b/front-nuxt/composables/useAccount.ts
@@ -1,7 +1,7 @@
 import type { AccountData } from '~/types';
 
 export const useAccount = () => {
-  const axios = useAxios();
+  const axios = useAxios('/account');
   // const { accountData } = storeToRefs(useUserStore());
 
   const updateAccountPassword = async (userInfo: AccountData) => {
@@ -9,7 +9,12 @@ export const useAccount = () => {
     await axios.post('/update-password/', userInfo);
   };
 
+  const updateAccount = async (userId: string, userInfo: AccountData) => {
+    await axios.patch('/account/' + userId, userInfo);
+  };
+
   return {
     updateAccountPassword,
+    updateAccount,
   };
 };

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -1,11 +1,9 @@
-import type { AxiosInstance } from 'axios';
-
 import type { AccountData } from '~/types';
 
 export const useAuth = () => {
-  const axios = useAxios();
+  const axios = useAxios('/auth');
   const NGINX_HOST = useRuntimeConfig().public.NGINX_HOST;
-  const { accountData, profileData } = storeToRefs(useUserStore());
+  const { accountData } = storeToRefs(useUserStore());
   const refreshTokenIntervalId = ref();
   const tokenDurationMins = Number(
     useRuntimeConfig().public.JWT_ACCESS_DURATION,
@@ -105,34 +103,14 @@ export const useAuth = () => {
       username: info.username,
       password: info.password,
     });
-    try {
-      const profileResponse = await axios.get('/profile', {
-        headers: { Authorization: `Bearer ${data.access_token}` },
-      });
-
-      console.log(profileResponse);
-      // Store profile data in the state
-      profileData.value = profileResponse.data;
-    } catch (error) {
-      // Handle the error by setting profileData to null
-      profileData.value = null;
-
-      // // Optionally, you can handle specific error statuses
-      // if (axios.isAxiosError(error) && error.response) {
-      //   const statusCode = error.response.status;
-      //   if (statusCode === 400) {
-      //     // Handle 400 Bad Request error specifically if needed
-      //   }
-      //   // Handle other status codes as necessary
-    }
     console.log('doLogin data check', data);
     accountData.value = { ...accountData.value, ...data };
     console.log('doLogin account data check', accountData.value);
     startRefreshAuth();
   };
 
-  const doLogout = async (api: AxiosInstance) => {
-    await api.delete('/logout');
+  const doLogout = async () => {
+    await axios.delete('/logout');
     accountData.value = {} as AccountData;
     stopRefreshAuth();
   };
@@ -145,11 +123,11 @@ export const useAuth = () => {
   };
 
   const onGoogleLogin = () =>
-    (window.location.href = `${NGINX_HOST}/api/google`);
+    (window.location.href = `${NGINX_HOST}/api/auth/google`);
 
-  const onFtLogin = () => (window.location.href = `${NGINX_HOST}/api/ft`);
+  const onFtLogin = () => (window.location.href = `${NGINX_HOST}/api/auth/ft`);
   const onGithubLogin = () => {
-    window.location.href = `${NGINX_HOST}/api/github`;
+    window.location.href = `${NGINX_HOST}/api/auth/github`;
   };
 
   return {

--- a/front-nuxt/composables/useAuth.ts
+++ b/front-nuxt/composables/useAuth.ts
@@ -4,7 +4,7 @@ import type { AccountData } from '~/types';
 
 export const useAuth = () => {
   const axios = useAxios();
-  const BACK_HOST = useRuntimeConfig().public.NGINX_HOST;
+  const NGINX_HOST = useRuntimeConfig().public.NGINX_HOST;
   const { accountData, profileData } = storeToRefs(useUserStore());
   const refreshTokenIntervalId = ref();
   const tokenDurationMins = Number(
@@ -144,11 +144,12 @@ export const useAuth = () => {
     await axios.post(`/forgot-password?lang=${lang}`, info);
   };
 
-  const onGoogleLogin = () => (window.location.href = `${BACK_HOST}/google`);
+  const onGoogleLogin = () =>
+    (window.location.href = `${NGINX_HOST}/api/google`);
 
-  const onFtLogin = () => (window.location.href = `${BACK_HOST}/ft`);
+  const onFtLogin = () => (window.location.href = `${NGINX_HOST}/api/ft`);
   const onGithubLogin = () => {
-    window.location.href = `${BACK_HOST}/github`;
+    window.location.href = `${NGINX_HOST}/api/github`;
   };
 
   return {

--- a/front-nuxt/composables/useAxios.ts
+++ b/front-nuxt/composables/useAxios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const useAxios = () => {
-  const baseURL = useRuntimeConfig().public.BACK_HOST;
+  const baseURL = `${useRuntimeConfig().public.NGINX_HOST}/api`;
   const { accountData } = storeToRefs(useUserStore());
   const api = axios.create({
     baseURL,

--- a/front-nuxt/composables/useAxios.ts
+++ b/front-nuxt/composables/useAxios.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 
-export const useAxios = () => {
-  const baseURL = `${useRuntimeConfig().public.NGINX_HOST}/api`;
+export const useAxios = (prefix: String = '') => {
+  const baseURL = `${useRuntimeConfig().public.NGINX_HOST}/api${prefix}`;
   const { accountData } = storeToRefs(useUserStore());
+  console.log('useAxios():', accountData.value, accountData.value.access_token);
   const api = axios.create({
     baseURL,
     headers: {

--- a/front-nuxt/composables/useProfile.ts
+++ b/front-nuxt/composables/useProfile.ts
@@ -1,4 +1,4 @@
-import type { AccountData, ProfileData } from '~/types';
+import type { ProfileData } from '~/types';
 
 const MAX_IMAGE_SIZE = 5242880; // 5MB
 
@@ -23,14 +23,6 @@ export const useProfile = () => {
       withCredentials: true, // Add this line to send cookies
     });
     return response;
-  };
-
-  const updateProfile = async (userId: string, userInfo: AccountData) => {
-    await axios.patch('/account/' + userId, userInfo);
-  };
-
-  const updateAccountPassword = async (userInfo: AccountData) => {
-    await axios.post('/update-password/', userInfo);
   };
 
   const getProfile = async () => {
@@ -67,7 +59,5 @@ export const useProfile = () => {
     getProfile,
     getSocialProfileImage,
     updateProfileImage,
-    updateProfile,
-    updateAccountPassword,
   };
 };

--- a/front-nuxt/composables/useProfile.ts
+++ b/front-nuxt/composables/useProfile.ts
@@ -4,6 +4,7 @@ const MAX_IMAGE_SIZE = 5242880; // 5MB
 
 export const useProfile = () => {
   const axios = useAxios();
+  const { profileData } = storeToRefs(useUserStore());
 
   const updateProfileImage = async (imagesToUpload: any) => {
     const formData = new FormData();
@@ -15,7 +16,7 @@ export const useProfile = () => {
       console.log(`${key}: ${value}`);
     }
 
-    const response = await axios.post('/api/profile/upload_image', formData, {
+    const response = await axios.post('/profile/upload_image', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
@@ -25,15 +26,28 @@ export const useProfile = () => {
   };
 
   const updateProfile = async (userId: string, userInfo: AccountData) => {
-    await axios.patch('/api/account/' + userId, userInfo);
+    await axios.patch('/account/' + userId, userInfo);
   };
 
   const updateAccountPassword = async (userInfo: AccountData) => {
-    await axios.post('/api/update-password/', userInfo);
+    await axios.post('/update-password/', userInfo);
+  };
+
+  const getProfile = async () => {
+    try {
+      const profileResponse = await axios.get('/profile');
+
+      console.log(profileResponse);
+      // Store profile data in the state
+      profileData.value = profileResponse.data;
+    } catch (error) {
+      // Handle the error by setting profileData to null
+      profileData.value = null;
+    }
   };
 
   const generateProfile = async (profileInfo: ProfileData) => {
-    console.log("profile", profileInfo)
+    console.log('profile', profileInfo);
     const result = await axios.post('/profile', profileInfo);
     return result.data;
   };
@@ -50,6 +64,7 @@ export const useProfile = () => {
   };
   return {
     generateProfile,
+    getProfile,
     getSocialProfileImage,
     updateProfileImage,
     updateProfile,

--- a/front-nuxt/pages/auth/login.vue
+++ b/front-nuxt/pages/auth/login.vue
@@ -103,6 +103,7 @@
   const username = ref('');
   const password = ref('');
   const { doLogin, onGoogleLogin, onGithubLogin, onFtLogin } = useAuth();
+  const { getProfile } = useProfile();
   const { isEmailVerified, isProfileGenerated, isProfileImageUploaded } =
     storeToRefs(useUserStore());
   const { t } = useI18n();
@@ -130,6 +131,7 @@
         username: username.value,
         password: password.value,
       });
+      await getProfile();
       if (isEmailVerified.value) {
         if (isProfileGenerated.value) {
           // User is verified and has a generated profile

--- a/front-nuxt/pages/auth/reset-password.vue
+++ b/front-nuxt/pages/auth/reset-password.vue
@@ -71,7 +71,7 @@
   const dirty = ref(false);
 
   const { accountData } = storeToRefs(useUserStore());
-  const { updateProfile } = useProfile();
+  const { updateAccount } = useAccount();
   const { updateAccountPassword } = useAccount();
 
   const { passwordValidator } = useValidator();
@@ -97,7 +97,7 @@
       loading.value = true;
       console.log('reset-password', accountData.value);
       // Simulate API call for resetting password
-      // await updateProfile(accountData.value.account_id, {
+      // await updateAccount(accountData.value.account_id, {
       //   password: newPassword.value,
       // });
       await updateAccountPassword({

--- a/server-nginx/conf/nginx.conf
+++ b/server-nginx/conf/nginx.conf
@@ -9,6 +9,10 @@ http {
 		server back:8000;
 	}
 
+	log_format api_logs '$remote_addr - $remote_user [$time_local] "$request" '
+						'$status $body_bytes_sent "$http_referer" '
+						'"$http_user_agent" "$http_x_forwarded_for"';
+
 	server {
 		listen 80;
 		server_name localhost;
@@ -34,7 +38,6 @@ http {
 		location /api {
 			rewrite /api(.*) $1 break;  # Strips '/api' from request URL
 
-			# proxy_pass http://express;
 			proxy_pass http://fastapi;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
@@ -51,6 +54,8 @@ http {
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "upgrade";
+
+			access_log /var/log/nginx/api_access_log api_logs;
 		}
 	}
 }


### PR DESCRIPTION
nginx를 통한 백엔드 요청시 api prefix로 통하도록 합니다

- back: 각 컨트롤러마다 해당 prefix를 붙입니다
- front: 해당 axios요청은 useProfile, useAccount 처럼 백 컨트롤러와 매칭되는 컴포져블로 모아놓습니다.


## 변경사항
- 프론트에서 모든 백요청은 NGINX_HOST를 통하도록 수정했습니다.
- 백요청은 `/api`를 붙여서 nginx를 통해 `/api` 제거합니다.
- useProfile, useAccount처럼 각 컴퍼져블마다 백 컨트롤러에 해당하는 prefix(e.g., `/auth`, `/account`)를 붙입니다.
  - useAxios 선언시 prefix를 인자로 받습니다.
  - 백 컨트롤러에서 APIrouter설정에 같은 prefix를 붙입니다.

## 기타
현재 auth, account만 수정했고 이후에 profile도 수정이 필요합니다.

close #61 